### PR TITLE
🔧 Fix handling of types without English common names

### DIFF
--- a/src/utils/buildTypeSchema.js
+++ b/src/utils/buildTypeSchema.js
@@ -83,8 +83,7 @@ const sortTypes = (types) =>
     )
 
 const getNames = (type) => {
-  const commonName =
-    type.name ?? (type.common_names.en && type.common_names.en[0])
+  const commonName = type.name ?? type.common_names.en?.[0]
   const scientificName = type.scientific_names?.[0]
   return {
     commonName,

--- a/src/utils/buildTypeSchema.js
+++ b/src/utils/buildTypeSchema.js
@@ -83,7 +83,8 @@ const sortTypes = (types) =>
     )
 
 const getNames = (type) => {
-  const commonName = type.name ?? type.common_names.en[0]
+  const commonName =
+    type.name ?? (type.common_names.en && type.common_names.en[0])
   const scientificName = type.scientific_names?.[0]
   return {
     commonName,
@@ -145,7 +146,7 @@ const updateTreeCounts = (
         <TreeNodeText
           commonName={commonName}
           shouldIncludeScientificName={scientificName}
-          shouldIncludeCommonName={!cultivarIndex}
+          shouldIncludeCommonName={commonName && !cultivarIndex}
           scientificName={
             cultivarIndex === -1
               ? scientificName


### PR DESCRIPTION
The API currently requires that a type have at least either an English common name or a scientific name. However, a type with only the former broke the building of the type tree, resulting is an empty tree. This pull request fixes this issue.