### PR TITLE
🔧 Fix creation and display of review fruiting and ratings

### DIFF
--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -116,7 +116,7 @@ const Review = ({
         {RATINGS.map(({ title, ratingKey, total }, key) => {
           const score = review[ratingKey]
 
-          if (!score) {
+          if (score === null) {
             return null
           }
 
@@ -127,7 +127,7 @@ const Review = ({
               </td>
               <td>
                 {ratingKey !== 'fruiting' ? (
-                  <Rating key={key} score={review[ratingKey]} total={total} />
+                  <Rating key={key} score={score + 1} total={total} />
                 ) : (
                   FRUITING_RATINGS[score]
                 )}

--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -143,8 +143,8 @@ const Review = ({
         <cite>
           Reviewed on {formatISOString(review.created_at)} by{' '}
           {review.author ?? 'Anonymous'}{' '}
-          {review.observed_at && (
-            <>(visited {formatISOString(review.observed_at)}))</>
+          {review.observed_on && (
+            <>(visited {formatISOString(review.observed_on)})</>
           )}
         </cite>
       )}

--- a/src/components/entry/ReviewSummary.js
+++ b/src/components/entry/ReviewSummary.js
@@ -44,12 +44,15 @@ const SummaryTable = styled.table`
 `
 
 const FruitingSummaryRow = ({ reviews }) => {
-  if (!reviews || reviews.length === 0) {
+  if (!reviews?.length) {
     return null
   }
 
   const reviewsByMonth = reviews.reduce((monthToCount, review) => {
-    const month = new Date(review.observed_at || review.created_at).getMonth()
+    if (!review.observed_on) {
+      return monthToCount
+    }
+    const month = new Date(review.observed_on).getMonth()
 
     monthToCount = {
       ...monthToCount,

--- a/src/components/entry/ReviewSummary.js
+++ b/src/components/entry/ReviewSummary.js
@@ -90,9 +90,9 @@ const FruitingSummary = ({ reviews }) => {
       <tr>
         <td colSpan={2}>Fruiting</td>
       </tr>
-      <FruitingSummaryRow reviews={ripeReviews} />
-      <FruitingSummaryRow reviews={unripeReviews} />
       <FruitingSummaryRow reviews={flowerReviews} />
+      <FruitingSummaryRow reviews={unripeReviews} />
+      <FruitingSummaryRow reviews={ripeReviews} />
     </>
   )
 }

--- a/src/components/entry/ReviewSummary.js
+++ b/src/components/entry/ReviewSummary.js
@@ -76,13 +76,11 @@ const FruitingSummaryRow = ({ reviews }) => {
 }
 
 const FruitingSummary = ({ reviews }) => {
-  const fruitingReviews = reviews.filter((review) => Boolean(review.fruiting))
-
   const {
-    1: flowerReviews,
-    2: unripeReviews,
-    3: ripeReviews,
-  } = groupBy(rProp('fruiting'), fruitingReviews)
+    0: flowerReviews,
+    1: unripeReviews,
+    2: ripeReviews,
+  } = groupBy(rProp('fruiting'), reviews)
 
   return (
     <>

--- a/src/components/form/ReviewForm.js
+++ b/src/components/form/ReviewForm.js
@@ -22,14 +22,19 @@ import {
 } from './FormikWrappers'
 import { useInvisibleRecaptcha } from './useInvisibleRecaptcha'
 
+/**
+ * Initial values of review form fields.
+ *
+ * These represent the value that each field resets to.
+ */
 export const INITIAL_REVIEW_VALUES = {
   review: {
     photos: [],
     comment: '',
     observed_on: '',
-    fruiting: 0,
-    quality_rating: 0,
-    yield_rating: 0,
+    fruiting: null,
+    quality_rating: '0',
+    yield_rating: '0',
   },
 }
 
@@ -37,7 +42,7 @@ export const INITIAL_REVIEW_VALUES = {
 export const FRUITING_OPTIONS = ['Flowers', 'Unripe fruit', 'Ripe fruit'].map(
   (name, idx) => ({
     label: name,
-    value: idx + 1,
+    value: idx,
   }),
 )
 
@@ -49,16 +54,16 @@ export const isEmptyReview = (review) => {
   const r = formToReview(review)
   return (
     !r.comment &&
-    r.quality_rating === 0 &&
-    r.fruiting === 0 &&
-    r.yield_rating === 0 &&
+    r.quality_rating === null &&
+    r.fruiting === null &&
+    r.yield_rating === null &&
     r.photo_ids.length === 0
   )
 }
 
 export const validateReviewStep = (review) => {
   const r = formToReview(review)
-  if (r.fruiting !== 0 && !r.observed_on) {
+  if (r.fruiting !== null && !r.observed_on) {
     return {
       review: { observed_on: true },
     }
@@ -91,10 +96,13 @@ export const validateReview = (review) => ({
 export const formToReview = (review) => {
   const formattedReview = {
     ...review,
+    comment: review.comment || null,
     observed_on: review.observed_on || null,
-    fruiting: review.fruiting?.value ?? 0,
-    quality_rating: Number(review.quality_rating),
-    yield_rating: Number(review.yield_rating),
+    fruiting: review.fruiting ? review.fruiting.value : null,
+    quality_rating:
+      review.quality_rating === '0' ? null : Number(review.quality_rating) - 1,
+    yield_rating:
+      review.yield_rating === '0' ? null : Number(review.yield_rating) - 1,
     photo_ids: review.photos.map((photo) => photo.id),
   }
   delete formattedReview.photos
@@ -109,7 +117,7 @@ export const reviewToForm = ({
   yield_rating,
   quality_rating,
 }) => ({
-  comment,
+  comment: comment ?? '',
   photos: photos.map((photo) => ({
     id: photo.id,
     name: `My Photo ${photo.created_at.split('T')[0]}`,
@@ -117,9 +125,9 @@ export const reviewToForm = ({
     isNew: false,
   })),
   observed_on: observed_on ?? '',
-  fruiting: fruiting === 0 ? null : FRUITING_OPTIONS[fruiting - 1],
-  yield_rating,
-  quality_rating,
+  fruiting: fruiting === null ? null : FRUITING_OPTIONS[fruiting],
+  yield_rating: yield_rating === null ? '0' : String(yield_rating + 1),
+  quality_rating: quality_rating === null ? '0' : String(quality_rating + 1),
 })
 
 const DeleteButton = styled(Button)`

--- a/src/constants/ratings.js
+++ b/src/constants/ratings.js
@@ -17,7 +17,7 @@ export const RATINGS = [
 ]
 
 export const FRUITING_RATINGS = {
-  1: 'Flowers',
-  2: 'Unripe',
-  3: 'Ripe Fruit',
+  0: 'Flowers',
+  1: 'Unripe fruit',
+  2: 'Ripe fruit',
 }


### PR DESCRIPTION
Review attributes `fruiting`, `quality_rating`, and `yield_rating` are now read, written, and displayed in a matter consistent with the zero-based scales used by the API.

Also fixes fruiting summary and review descriptions to use `observed_on` (misspelled `observed_at`).

Closes #331 .