### PR TITLE
💖 Display line breaks in text fields from API

### DIFF
--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -47,6 +47,9 @@ const IconBesideText = styled.div`
 
 // Wraps description, last updated text, and review and report buttons
 const Description = styled.section`
+  white-space: pre-line;
+  word-break: break-all;
+
   p {
     font-size: 1rem;
   }
@@ -113,9 +116,7 @@ const EntryOverview = ({ locationData, className }) => {
         <TextContent>
           <TypesHeader typeIds={locationData.type_ids} />
           <Description>
-            <p style={{ 'white-space': 'pre-line' }}>
-              {locationData.description}
-            </p>
+            <p>{locationData.description}</p>
 
             <IconBesideText bold onClick={handleAddressClick} tabIndex={0}>
               <Map color={theme.secondaryText} size={20} />

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -113,7 +113,9 @@ const EntryOverview = ({ locationData, className }) => {
         <TextContent>
           <TypesHeader typeIds={locationData.type_ids} />
           <Description>
-            <p>{locationData.description}</p>
+            <p style={{ 'white-space': 'pre-line' }}>
+              {locationData.description}
+            </p>
 
             <IconBesideText bold onClick={handleAddressClick} tabIndex={0}>
               <Map color={theme.secondaryText} size={20} />

--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -138,7 +138,9 @@ const Review = ({
       </tbody>
     </RatingTable>
     <ReviewDescription>
-      <blockquote>{review.comment}</blockquote>
+      <blockquote style={{ 'white-space': 'pre-line' }}>
+        {review.comment}
+      </blockquote>
       {!editable && (
         <cite>
           Reviewed on {formatISOString(review.created_at)} by{' '}

--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -59,6 +59,9 @@ const RatingTable = styled.table`
   }
 `
 const ReviewDescription = styled.section`
+  white-space: pre-line;
+  word-break: break-all;
+
   margin-bottom: 8px;
   blockquote {
     font-size: 1rem;
@@ -138,9 +141,7 @@ const Review = ({
       </tbody>
     </RatingTable>
     <ReviewDescription>
-      <blockquote style={{ 'white-space': 'pre-line' }}>
-        {review.comment}
-      </blockquote>
+      <blockquote>{review.comment}</blockquote>
       {!editable && (
         <cite>
           Reviewed on {formatISOString(review.created_at)} by{' '}


### PR DESCRIPTION
Sets CSS `white-space: pre-line` to elements displaying the following attributes:

- Location.description
- Review.comment

This ensures that line breaks (`\n`) are displayed correctly and as they appear in the form text areas.

@Qrtn @SirajChokshi Is this the best way to achieve this (setting style on elements directly), or can just the style be made into a reusable component? This situation could occur anywhere that a text field (user bio, dataset comments, ...) is displayed outside a textarea input.