### PR TITLE
✨ Only wrap words that would otherwise overflow

### DIFF
--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -48,7 +48,8 @@ const IconBesideText = styled.div`
 // Wraps description, last updated text, and review and report buttons
 const Description = styled.section`
   white-space: pre-line;
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: anywhere;
 
   p {
     font-size: 1rem;
@@ -116,9 +117,7 @@ const EntryOverview = ({ locationData, className }) => {
         <TextContent>
           <TypesHeader typeIds={locationData.type_ids} />
           <Description>
-            <p style={{ 'white-space': 'pre-line' }}>
-              {locationData.description}
-            </p>
+            <p>{locationData.description}</p>
 
             <IconBesideText bold onClick={handleAddressClick} tabIndex={0}>
               <Map color={theme.secondaryText} size={20} />

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -113,7 +113,9 @@ const EntryOverview = ({ locationData, className }) => {
         <TextContent>
           <TypesHeader typeIds={locationData.type_ids} />
           <Description>
-            <p>{locationData.description}</p>
+            <p style={{ 'white-space': 'pre-line' }}>
+              {locationData.description}
+            </p>
 
             <IconBesideText bold onClick={handleAddressClick} tabIndex={0}>
               <Map color={theme.secondaryText} size={20} />

--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -60,7 +60,8 @@ const RatingTable = styled.table`
 `
 const ReviewDescription = styled.section`
   white-space: pre-line;
-  word-break: break-all;
+  word-break: normal;
+  overflow-wrap: anywhere;
 
   margin-bottom: 8px;
   blockquote {
@@ -141,9 +142,7 @@ const Review = ({
       </tbody>
     </RatingTable>
     <ReviewDescription>
-      <blockquote style={{ 'white-space': 'pre-line' }}>
-        {review.comment}
-      </blockquote>
+      <blockquote>{review.comment}</blockquote>
       {!editable && (
         <cite>
           Reviewed on {formatISOString(review.created_at)} by{' '}

--- a/src/components/entry/Review.js
+++ b/src/components/entry/Review.js
@@ -138,7 +138,9 @@ const Review = ({
       </tbody>
     </RatingTable>
     <ReviewDescription>
-      <blockquote>{review.comment}</blockquote>
+      <blockquote style={{ 'white-space': 'pre-line' }}>
+        {review.comment}
+      </blockquote>
       {!editable && (
         <cite>
           Reviewed on {formatISOString(review.created_at)} by{' '}


### PR DESCRIPTION
 Since CSS `word-break: break-word` is deprecated, this uses the equivalent

- `word-break: normal` (the default)
- `overflow-wrap: anywhere`

See https://github.com/falling-fruit/falling-fruit-web/pull/336.