### PR TITLE
👱🏿‍♀️ Drop region code from locale

### DIFF
--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
 
+import { LANGUAGE_OPTIONS } from '../../i18n'
 import { updateSettings } from '../../redux/settingsSlice'
 import { useAppHistory } from '../../utils/useAppHistory'
 import Button from '../ui/Button'
@@ -18,14 +19,6 @@ import Road from './mapTiles/road.png'
 import Satellite from './mapTiles/satellite.png'
 import Terrain from './mapTiles/terrain.png'
 import Transit from './mapTiles/transit.png'
-
-const LANGUAGE_OPTIONS = [
-  { value: 'en-US', label: 'English' },
-  { value: 'fr', label: 'Français' },
-  { value: 'es', label: 'Español' },
-  { value: 'de', label: 'Deutsch' },
-  { value: 'it', label: 'Italiano' },
-]
 
 const DISTANCE_UNIT_OPTIONS = [
   { value: 'metric', label: 'Metric' },

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -3,6 +3,11 @@ import LanguageDetector from 'i18next-browser-languagedetector'
 import Backend from 'i18next-http-backend'
 import { initReactI18next } from 'react-i18next'
 
+export const LANGUAGE_OPTIONS = [
+  { value: 'en', label: 'English' },
+  { value: 'fr', label: 'Français' },
+]
+
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
   .use(Backend)
@@ -11,6 +16,7 @@ i18n
     react: {
       useSuspense: false,
     },
+    supportedLngs: LANGUAGE_OPTIONS.map((option) => option.value),
     fallbackLng: 'en', // default language if no language is detected by LanguageDetector
     interpolation: {
       escapeValue: false,

--- a/src/redux/useTypesById.js
+++ b/src/redux/useTypesById.js
@@ -4,13 +4,12 @@ import { useSelector } from 'react-redux'
 
 export const useTypesById = () => {
   const { i18n } = useTranslation()
-  const language = i18n.language === 'en-US' ? 'en' : i18n.language
 
   const typesById = useSelector((state) => state.misc.typesById)
 
   const getCommonNames = useCallback(
-    (id) => typesById[id]?.common_names[language],
-    [typesById, language],
+    (id) => typesById[id]?.common_names[i18n.language],
+    [typesById, i18n.language],
   )
 
   const getCommonName = (id) => getCommonNames(id)?.[0]


### PR DESCRIPTION
Ensures that i18n.language is a language code with no region code (e.g. 'en', not 'en-US' or 'en-GB'), simplifying and fixing app logic.

Closes #293.