### PR TITLE
😤 Match paths of existing website

### DIFF
--- a/src/components/about/ProjectPage.js
+++ b/src/components/about/ProjectPage.js
@@ -84,21 +84,21 @@ const Project = () => (
           world's most comprehensive. While our users contribute locations of
           their own, we comb the internet for pre-existing knowledge, seeking to
           unite the efforts of foragers, foresters, and freegans everywhere. The{' '}
-          <a href="/about/data">imported datasets</a> range from small
-          neighborhood foraging maps to vast professionally-compiled tree
-          inventories. This so far amounts to thousands of different types of
-          edibles (most, but not all, plant species) distributed over millions
-          of locations. Beyond the cultivated and commonplace to the exotic
-          flavors of foreign plants and long-forgotten native plants, foraging
-          in your neighborhood is a journey through time and across cultures.
+          <a href="/data">imported datasets</a> range from small neighborhood
+          foraging maps to vast professionally-compiled tree inventories. This
+          so far amounts to thousands of different types of edibles (most, but
+          not all, plant species) distributed over millions of locations. Beyond
+          the cultivated and commonplace to the exotic flavors of foreign plants
+          and long-forgotten native plants, foraging in your neighborhood is a
+          journey through time and across cultures.
         </p>
         <p>
           Join us in celebrating hyper-local food! The <a href="/map">map</a> is
           open for anyone to edit, the database can be{' '}
-          <a href="/about/data">downloaded</a> with just one click, and the{' '}
+          <a href="/data">downloaded</a> with just one click, and the{' '}
           <a href="https://github.com/falling-fruit">code</a> is open-source.
           You are likewise encouraged to share the bounty with your fellow
-          humans. Our <a href="/about/share">sharing page</a> lists hundreds of
+          humans. Our <a href="/sharing">sharing page</a> lists hundreds of
           local organizations - planting public orchards and food forests,
           picking otherwise-wasted fruits and vegetables from city trees and
           farmers' fields, and sharing with neighbors and the needy.

--- a/src/components/about/aboutRoutes.js
+++ b/src/components/about/aboutRoutes.js
@@ -8,26 +8,28 @@ import ShareTheHarvestPage from './ShareTheHarvestPage'
 
 const pages = [
   {
-    path: '/about/project',
+    path: ['/about'],
     component: ProjectPage,
   },
   {
-    path: '/about/dataset/:id',
+    path: ['/imports/:id'],
     component: AboutDatasetPage,
   },
   {
-    path: '/about/data',
+    path: ['/data', '/datasets'],
     component: DataPage,
   },
   {
-    path: '/about/press',
+    path: ['/press'],
     component: InThePressPage,
   },
   {
-    path: '/about/share',
+    path: ['/sharing'],
     component: ShareTheHarvestPage,
   },
 ]
 
-const aboutRoutes = pages.map((props) => <Route key={props.path} {...props} />)
+const aboutRoutes = pages.map((props) => (
+  <Route key={props.path[0]} {...props} />
+))
 export default aboutRoutes

--- a/src/components/auth/AccountPage.js
+++ b/src/components/auth/AccountPage.js
@@ -55,7 +55,7 @@ const AccountPage = () => {
   }, [])
 
   if (!isLoading && !isLoggedIn) {
-    return <Redirect to={getPathWithMapState('/login')} />
+    return <Redirect to={getPathWithMapState('/users/sign_in')} />
   }
 
   const handleSubmit = async (values) => {

--- a/src/components/auth/ConfirmationPage.js
+++ b/src/components/auth/ConfirmationPage.js
@@ -13,15 +13,15 @@ const ConfirmationPage = () => {
 
       if (!token) {
         toast.error("Confirmation token can't be blank", { autoClose: 5000 })
-        history.push('/confirmation/new')
+        history.push('/users/confirmation/new')
       } else {
         try {
           const { email } = await confirmUser(token)
           toast.success('Your email has been confirmed.')
-          history.push({ pathname: '/login', state: { email } })
+          history.push({ pathname: '/users/sign_in', state: { email } })
         } catch (e) {
           toast.error(e.response?.data.error, { autoClose: 5000 })
-          history.push('/confirmation/new')
+          history.push('/users/confirmation/new')
         }
       }
     }

--- a/src/components/auth/ConfirmationResendPage.js
+++ b/src/components/auth/ConfirmationResendPage.js
@@ -27,7 +27,7 @@ const ConfirmationResendPage = () => {
         'You will receive an email with instructions for how to confirm your email address in a few minutes',
         { autoClose: 5000 },
       )
-      history.push('/login')
+      history.push('/users/sign_in')
     } catch (e) {
       toast.error(e.response?.data.error)
       console.error(e.response)
@@ -40,9 +40,11 @@ const ConfirmationResendPage = () => {
       <h1>Resend confirmation instructions</h1>
       <EmailForm onSubmit={handleSubmit} recaptchaRef={recaptchaRef} />
       <Column>
-        <Link to="/login">Login</Link>
-        <Link to="/signup">Sign up</Link>
-        <Link to="/confirmation/new">Resend confirmation instructions</Link>
+        <Link to="/users/sign_in">Login</Link>
+        <Link to="/users/sign_up">Sign up</Link>
+        <Link to="/users/confirmation/new">
+          Resend confirmation instructions
+        </Link>
       </Column>
     </PageTemplate>
   )

--- a/src/components/auth/LoginPage.js
+++ b/src/components/auth/LoginPage.js
@@ -75,9 +75,11 @@ const LoginPage = () => {
           )}
         </Formik>
         <Column>
-          <Link to="/signup">Sign up</Link>
-          <Link to="/password/reset">Reset your password</Link>
-          <Link to="/confirmation/new">Resend confirmation instructions</Link>
+          <Link to="/users/sign_up">Sign up</Link>
+          <Link to="/users/password/new">Reset your password</Link>
+          <Link to="/users/confirmation/new">
+            Resend confirmation instructions
+          </Link>
         </Column>
       </PageTemplate>
     </PageScrollWrapper>

--- a/src/components/auth/PasswordResetPage.js
+++ b/src/components/auth/PasswordResetPage.js
@@ -27,7 +27,7 @@ const PasswordResetPage = () => {
         'You will receive an email with instructions on how to reset your password in a few minutes',
         { autoClose: 5000 },
       )
-      history.push('/login')
+      history.push('/users/sign_in')
     } catch (e) {
       toast.error('Email not found')
       console.error(e.response)
@@ -40,9 +40,11 @@ const PasswordResetPage = () => {
       <h1>Send password reset instructions</h1>
       <EmailForm onSubmit={handleSubmit} recaptchaRef={recaptchaRef} />
       <Column>
-        <Link to="/login">Login</Link>
-        <Link to="/signup">Sign up</Link>
-        <Link to="/confirmation/new">Resend confirmation instructions</Link>
+        <Link to="/users/sign_in">Login</Link>
+        <Link to="/users/sign_up">Sign up</Link>
+        <Link to="/users/confirmation/new">
+          Resend confirmation instructions
+        </Link>
       </Column>
     </PageTemplate>
   )

--- a/src/components/auth/PasswordSetPage.js
+++ b/src/components/auth/PasswordSetPage.js
@@ -27,7 +27,7 @@ const PasswordSetPage = () => {
         "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.",
         { autoClose: 5000 },
       )
-      history.push('/login')
+      history.push('/users/sign_in')
     }
   }, [history])
 
@@ -44,11 +44,11 @@ const PasswordSetPage = () => {
       toast.success('Your password has been changed successfully.', {
         autoClose: 5000,
       })
-      history.push({ pathname: '/login', state: { email } })
+      history.push({ pathname: '/users/sign_in', state: { email } })
     } catch (e) {
       toast.error('Invalid password reset link')
       console.error(e.response)
-      history.push('/login')
+      history.push('/users/sign_in')
     }
   }
 
@@ -91,9 +91,11 @@ const PasswordSetPage = () => {
         )}
       </Formik>
       <Column>
-        <Link to="/login">Login</Link>
-        <Link to="/signup">Sign up</Link>
-        <Link to="/confirmation/new">Resend confirmation instructions</Link>
+        <Link to="/users/sign_in">Login</Link>
+        <Link to="/users/sign_up">Sign up</Link>
+        <Link to="/users/confirmation/new">
+          Resend confirmation instructions
+        </Link>
       </Column>
     </PageTemplate>
   )

--- a/src/components/auth/SignupPage.js
+++ b/src/components/auth/SignupPage.js
@@ -53,7 +53,7 @@ const SignupPage = () => {
       <PageTemplate>
         <h1>Sign up</h1>
         <LoginNotice>
-          Have an account? <Link to="/login">Login</Link>
+          Have an account? <Link to="/users/sign_in">Login</Link>
         </LoginNotice>
 
         <Formik

--- a/src/components/auth/authRoutes.js
+++ b/src/components/auth/authRoutes.js
@@ -10,31 +10,31 @@ import SignupPage from './SignupPage'
 
 const pages = [
   {
-    path: '/account',
+    path: '/users/edit',
     component: AccountPage,
   },
   {
-    path: '/login',
+    path: '/users/sign_in',
     component: LoginPage,
   },
   {
-    path: '/signup',
+    path: '/users/sign_up',
     component: SignupPage,
   },
   {
-    path: '/password/reset',
+    path: '/users/password/new',
     component: PasswordResetPage,
   },
   {
-    path: '/password/set',
+    path: '/users/password/edit',
     component: PasswordSetPage,
   },
   {
-    path: '/confirmation/new',
+    path: '/users/confirmation/new',
     component: ConfirmationResendPage,
   },
   {
-    path: '/confirmation',
+    path: '/users/confirmation',
     component: ConfirmationPage,
   },
 ]

--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -190,7 +190,7 @@ const Header = () => {
     matchPath(useLocation().pathname, {
       path: aboutRoutes.map((route) => route.props.path).flat(),
     }) !== null
-  const isAccountPage = useRouteMatch('/account') !== null
+  const isAccountPage = useRouteMatch('/users/edit') !== null
 
   return (
     <StyledHeader>
@@ -232,7 +232,7 @@ const Header = () => {
                 }
                 isMatch={isAccountPage}
               >
-                <NavLink to="/account" activeClassName="active">
+                <NavLink to="/users/edit" activeClassName="active">
                   {t('My Account')}
                 </NavLink>
                 <ResetButton onClick={handleLogout}>Logout</ResetButton>
@@ -241,12 +241,12 @@ const Header = () => {
           ) : (
             <>
               <li>
-                <NavLink to="/login" activeClassName="active">
+                <NavLink to="/users/sign_in" activeClassName="active">
                   {t('Login')}
                 </NavLink>
               </li>
               <li>
-                <NavLink to="/signup" activeClassName="active">
+                <NavLink to="/users/sign_up" activeClassName="active">
                   <SignupButton>{t('Sign up')}</SignupButton>
                 </NavLink>
               </li>

--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -2,10 +2,12 @@ import { CaretDown } from '@styled-icons/boxicons-regular'
 import { User } from '@styled-icons/boxicons-solid'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Link, NavLink, useRouteMatch } from 'react-router-dom'
+import { matchPath } from 'react-router'
+import { Link, NavLink, useLocation, useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { logout } from '../../redux/authSlice'
+import aboutRoutes from '../about/aboutRoutes'
 import Button from '../ui/Button'
 import ResetButton from '../ui/ResetButton'
 
@@ -184,7 +186,10 @@ const Header = () => {
     dispatch(logout())
   }
 
-  const isAboutPage = useRouteMatch('/about/:slug') !== null
+  const isAboutPage =
+    matchPath(useLocation().pathname, {
+      path: aboutRoutes.map((route) => route.props.path).flat(),
+    }) !== null
   const isAccountPage = useRouteMatch('/account') !== null
 
   return (
@@ -201,16 +206,16 @@ const Header = () => {
           </li>
           <li>
             <StyledDropdown label={t('About')} isMatch={isAboutPage}>
-              <NavLink to="/about/project" activeClassName="active">
+              <NavLink to="/about" activeClassName="active">
                 {t('The project')}
               </NavLink>
-              <NavLink to="/about/data" activeClassName="active">
+              <NavLink to="/data" activeClassName="active">
                 {t('The data')}
               </NavLink>
-              <NavLink to="/about/share" activeClassName="active">
+              <NavLink to="/sharing" activeClassName="active">
                 {t('Sharing the harvest')}
               </NavLink>
-              <NavLink to="/about/press" activeClassName="active">
+              <NavLink to="/press" activeClassName="active">
                 {t('In the press')}
               </NavLink>
             </StyledDropdown>

--- a/src/components/desktop/MainPane.js
+++ b/src/components/desktop/MainPane.js
@@ -36,7 +36,7 @@ const MainPane = () => {
         secondary
         onClick={() =>
           history.push({
-            pathname: '/entry/new',
+            pathname: '/locations/new',
             state: { fromPage: '/map' },
           })
         }

--- a/src/components/desktop/NavBack.js
+++ b/src/components/desktop/NavBack.js
@@ -25,13 +25,13 @@ const NavBack = ({ isEntry }) => {
   const history = useAppHistory()
   const { state } = useLocation()
   const { t } = useTranslation()
-  const match = useRouteMatch('/entry/:id')
+  const match = useRouteMatch('/locations/:id')
   const entryId = match?.params.id
 
-  const isEditingEntry = useRouteMatch('/entry/:id/edit')
+  const isEditingEntry = useRouteMatch('/locations/:id/edit')
 
   const handleBackButtonClick = () => {
-    // Default to going back to the map. This occurs when the user opens /entry/{typeId} directly
+    // Default to going back to the map. This occurs when the user opens /locations/:id directly
     if (isEditingEntry) {
       history.push(match.url)
     } else {
@@ -46,7 +46,7 @@ const NavBack = ({ isEntry }) => {
         {t('Back')}
       </BackButton>
       {isEntry && match && !isEditingEntry && (
-        <BackButton onClick={() => history.push(`/entry/${entryId}/edit`)}>
+        <BackButton onClick={() => history.push(`/locations/${entryId}/edit`)}>
           <Pencil />
           Edit
         </BackButton>

--- a/src/components/desktop/SidePaneSwitch.js
+++ b/src/components/desktop/SidePaneSwitch.js
@@ -18,7 +18,7 @@ const SidePaneSwitch = () => (
           <Route path="/locations/:id/edit">
             <EditLocationPage />
           </Route>
-          <Route path="/review/:id/edit">
+          <Route path="/reviews/:id/edit">
             <EditReviewPage />
           </Route>
           <Route path="/locations/new">

--- a/src/components/desktop/SidePaneSwitch.js
+++ b/src/components/desktop/SidePaneSwitch.js
@@ -15,19 +15,19 @@ const SidePaneSwitch = () => (
     <Route>
       <NavPane>
         <Switch>
-          <Route path="/entry/:id/edit">
+          <Route path="/locations/:id/edit">
             <EditLocationPage />
           </Route>
           <Route path="/review/:id/edit">
             <EditReviewPage />
           </Route>
-          <Route path="/entry/new">
+          <Route path="/locations/new">
             <LocationForm />
           </Route>
           <Route path="/settings">
             <SettingsPage desktop />
           </Route>
-          <Route path={['/entry/:id', '/entry/:id']}>
+          <Route path={['/locations/:id', '/locations/:id']}>
             <EntryWrapper desktop />
           </Route>
           <Route>

--- a/src/components/entry/EntryMobile.js
+++ b/src/components/entry/EntryMobile.js
@@ -299,7 +299,7 @@ const EntryMobile = ({
             {!isInDrawer && (
               <EntryButton
                 onClick={() =>
-                  history.push(`/entry/${locationData.id}`, {
+                  history.push(`/locations/${locationData.id}`, {
                     fromPage: '/map',
                   })
                 }
@@ -308,7 +308,7 @@ const EntryMobile = ({
               />
             )}
             <EntryButton
-              onClick={() => history.push(`/entry/${locationData.id}/edit`)}
+              onClick={() => history.push(`/locations/${locationData.id}/edit`)}
               icon={<PencilIcon />}
               label="edit-button"
             />

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -157,7 +157,7 @@ const EntryOverview = ({ locationData, className }) => {
                 {t('Imported from')}{' '}
                 <Link
                   to={{
-                    pathname: `/about/dataset/${locationData.import_id}`,
+                    pathname: `/imports/${locationData.import_id}`,
                     state: { fromPage: `/entry/${locationData.id}` },
                   }}
                 >

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -97,7 +97,7 @@ const EntryOverview = ({ locationData, className }) => {
 
   const handleStreetView = () => {
     if (!isDesktop) {
-      history.push(`/entry/${locationData.id}`, { fromPage: '/map' })
+      history.push(`/locations/${locationData.id}`, { fromPage: '/map' })
     }
 
     // TODO: change setTimeout to make it wait for map component to mount
@@ -158,7 +158,7 @@ const EntryOverview = ({ locationData, className }) => {
                 <Link
                   to={{
                     pathname: `/imports/${locationData.import_id}`,
-                    state: { fromPage: `/entry/${locationData.id}` },
+                    state: { fromPage: `/locations/${locationData.id}` },
                   }}
                 >
                   {locationData.author}

--- a/src/components/entry/EntryReviews.js
+++ b/src/components/entry/EntryReviews.js
@@ -33,7 +33,7 @@ const EntryReviews = ({ reviews, onImageClick, onReviewSubmit }) => {
               onImageClick={onReviewImageClick}
               onEditClick={() =>
                 history.push({
-                  pathname: `/review/${review.id}/edit`,
+                  pathname: `/reviews/${review.id}/edit`,
                   state: {
                     fromPage: history.location.pathname,
                   },

--- a/src/components/entry/ReviewButton.js
+++ b/src/components/entry/ReviewButton.js
@@ -18,7 +18,7 @@ export const ReviewButton = (props) => {
           window.location.hash = ''
           window.location.hash = 'review'
         } else {
-          history.push(`/entry/${id}/review`)
+          history.push(`/locations/${id}/review`)
         }
       }}
       {...props}

--- a/src/components/form/EditableForm.js
+++ b/src/components/form/EditableForm.js
@@ -46,7 +46,7 @@ export const EditReviewForm = (props) => (
     convertFormData={(review) => ({
       review: reviewToForm(review),
     })}
-    getRedirectLink={(review) => `/entry/${review.location_id}`}
+    getRedirectLink={(review) => `/locations/${review.location_id}`}
     {...props}
   />
 )

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -280,7 +280,8 @@ export const LocationForm = ({
         ]),
   ]
 
-  onSubmit = onSubmit ?? ((response) => history.push(`/entry/${response.id}`))
+  onSubmit =
+    onSubmit ?? ((response) => history.push(`/locations/${response.id}`))
   const handleSubmit = async ({
     'g-recaptcha-response': recaptcha,
     review,
@@ -342,7 +343,7 @@ export const LocationForm = ({
               onClick={(e) => {
                 e.stopPropagation()
                 if (editingId) {
-                  history.push(`/entry/${editingId}`)
+                  history.push(`/locations/${editingId}`)
                 } else {
                   history.push(state?.fromPage ?? '/map')
                 }

--- a/src/components/form/LocationNav.js
+++ b/src/components/form/LocationNav.js
@@ -20,30 +20,30 @@ const LocationNav = () => {
         {({ match }) => (
           // TODO: fix going back to correct entry id
           <TopBarNav
-            onBack={() => history.push(`/entry/${match.params.id}`)}
+            onBack={() => history.push(`/locations/${match.params.id}`)}
             title="Editing Review"
           />
         )}
       </Route>
-      <Route path="/entry/:id/review">
+      <Route path="/locations/:id/review">
         {({ match }) => (
           <TopBarNav
-            onBack={() => history.push(`/entry/${match.params.id}`)}
+            onBack={() => history.push(`/locations/${match.params.id}`)}
             title="Adding Review"
           />
         )}
       </Route>
-      <Route path="/entry/:id/edit">
+      <Route path="/locations/:id/edit">
         {({ match }) => (
           <TopBarNav
-            onBack={() => history.push(`/entry/${match.params.id}`)}
+            onBack={() => history.push(`/locations/${match.params.id}`)}
             title="Editing Location"
           />
         )}
       </Route>
-      <Route path="/entry/new/details">
+      <Route path="/locations/new/details">
         <TopBarNav
-          onBack={() => history.push('/entry/new')}
+          onBack={() => history.push('/locations/new')}
           title="New Location"
         />
       </Route>

--- a/src/components/form/LocationNav.js
+++ b/src/components/form/LocationNav.js
@@ -16,7 +16,7 @@ const LocationNav = () => {
 
   return (
     <Switch>
-      <Route path="/review/:id/edit">
+      <Route path="/reviews/:id/edit">
         {({ match }) => (
           // TODO: fix going back to correct entry id
           <TopBarNav

--- a/src/components/list/InfiniteList.js
+++ b/src/components/list/InfiniteList.js
@@ -20,7 +20,7 @@ const InfiniteList = ({
 
   const handleEntryClick = (id) => {
     history.push({
-      pathname: `/entry/${id}`,
+      pathname: `/locations/${id}`,
       state: { fromPage: '/list' },
     })
   }

--- a/src/components/list/PagedList.js
+++ b/src/components/list/PagedList.js
@@ -62,7 +62,7 @@ const PagedList = () => {
 
   const handleEntryClick = (id) => {
     history.push({
-      pathname: `/entry/${id}`,
+      pathname: `/locations/${id}`,
       state: { fromPage: '/list' },
     })
     dispatch(setHoveredLocationId(null))

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -29,7 +29,7 @@ const BottomLeftLoadingIndicator = styled(LoadingIndicator)`
 const MapPage = ({ isDesktop }) => {
   const history = useAppHistory()
   const match = useRouteMatch({
-    path: '/entry/:entryId',
+    path: '/locations/:entryId',
   })
 
   const isAddingLocation = match?.params.entryId === 'new'
@@ -57,13 +57,13 @@ const MapPage = ({ isDesktop }) => {
 
   const handleLocationClick = (location) => {
     history.push({
-      pathname: `/entry/${location.id}`,
+      pathname: `/locations/${location.id}`,
       state: { fromPage: '/map' },
     })
   }
 
   const handleAddLocationClick = () => {
-    history.push('/entry/new')
+    history.push('/locations/new')
   }
 
   return (

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -41,7 +41,7 @@ const MobileLayout = () => {
   ))
 
   if (
-    ['/list', '/settings', '/account'].some((path) =>
+    ['/list', '/settings', '/users/edit'].some((path) =>
       matchPath(pathname, { path, exact: false, strict: false }),
     )
   ) {
@@ -96,7 +96,7 @@ const MobileLayout = () => {
               <Route path="/settings">
                 <SettingsPage />
               </Route>
-              <Route path="/account">
+              <Route path="/users/edit">
                 <AccountPage />
               </Route>
             </Switch>

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -63,7 +63,7 @@ const MobileLayout = () => {
         <Switch>
           {aboutRoutes}
           {authRoutes}
-          <Route path="/review/:id/edit">
+          <Route path="/reviews/:id/edit">
             {({ match }) => (
               <EditReviewForm stepped editingId={match.params.id} />
             )}
@@ -106,7 +106,7 @@ const MobileLayout = () => {
       <Switch>
         <Route
           path={[
-            '/review/:id/edit',
+            '/reviews/:id/edit',
             '/locations/:id/review',
             '/locations/:id/edit',
             '/locations/new/details',
@@ -119,7 +119,7 @@ const MobileLayout = () => {
       <Switch>
         <Route
           path={[
-            '/review/:id/edit',
+            '/reviews/:id/edit',
             '/locations/:id/review',
             '/locations/:id/edit',
             '/locations/new/details',

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -68,24 +68,26 @@ const MobileLayout = () => {
               <EditReviewForm stepped editingId={match.params.id} />
             )}
           </Route>
-          <Route path="/entry/:id/review">
+          <Route path="/locations/:id/review">
             {({ match }) => (
               <ReviewForm
                 stepped
-                onSubmit={() => history.push(`/entry/${match.params.id}`)}
+                onSubmit={() => history.push(`/locations/${match.params.id}`)}
               />
             )}
           </Route>
-          <Route path="/entry/:id/edit">
+          <Route path="/locations/:id/edit">
             {({ match }) => <EditLocationForm editingId={match.params.id} />}
           </Route>
-          <Route path="/entry/new/details">
+          <Route path="/locations/new/details">
             <LocationForm />
           </Route>
-          <Route path={['/map', '/entry', '/list', '/settings']}>
+          <Route path={['/map', '/locations', '/list', '/settings']}>
             <Switch>
-              <Route path="/entry/new" />
-              <Route path="/entry/:id">{!streetView && <EntryWrapper />}</Route>
+              <Route path="/locations/new" />
+              <Route path="/locations/:id">
+                {!streetView && <EntryWrapper />}
+              </Route>
             </Switch>
             <Switch>
               <Route path="/list">
@@ -105,12 +107,12 @@ const MobileLayout = () => {
         <Route
           path={[
             '/review/:id/edit',
-            '/entry/:id/review',
-            '/entry/:id/edit',
-            '/entry/new/details',
+            '/locations/:id/review',
+            '/locations/:id/edit',
+            '/locations/new/details',
           ]}
         />
-        <Route path={['/map', '/entry']}>
+        <Route path={['/map', '/locations']}>
           {(pathname.includes('/map') || !isFromList) && <MapPage />}
         </Route>
       </Switch>
@@ -118,9 +120,9 @@ const MobileLayout = () => {
         <Route
           path={[
             '/review/:id/edit',
-            '/entry/:id/review',
-            '/entry/:id/edit',
-            '/entry/new/details',
+            '/locations/:id/review',
+            '/locations/:id/edit',
+            '/locations/new/details',
           ]}
         />
         <Route>

--- a/src/components/mobile/TopBarSwitch.js
+++ b/src/components/mobile/TopBarSwitch.js
@@ -13,12 +13,12 @@ const TopBarSwitch = () => {
       <Route
         path={[
           '/settings',
-          '/account',
+          '/users/edit',
           '/about',
-          '/signup',
-          '/login',
-          '/password',
-          '/confirmation',
+          '/users/sign_up',
+          '/users/sign_in',
+          '/users/password',
+          '/users/confirmation',
         ]}
       ></Route>
       <Route

--- a/src/components/mobile/TopBarSwitch.js
+++ b/src/components/mobile/TopBarSwitch.js
@@ -24,16 +24,16 @@ const TopBarSwitch = () => {
       <Route
         path={[
           '/review/:id/edit',
-          '/entry/:id/review',
-          '/entry/:id/edit',
-          '/entry/new',
+          '/locations/:id/review',
+          '/locations/:id/edit',
+          '/locations/new',
         ]}
       >
         <TopBar>
           <LocationNav />
         </TopBar>
       </Route>
-      {isFromList && <Route path="/entry/:id" />}
+      {isFromList && <Route path="/locations/:id" />}
       <Route>
         <TopBar>
           <Search />

--- a/src/components/mobile/TopBarSwitch.js
+++ b/src/components/mobile/TopBarSwitch.js
@@ -23,7 +23,7 @@ const TopBarSwitch = () => {
       ></Route>
       <Route
         path={[
-          '/review/:id/edit',
+          '/reviews/:id/edit',
           '/locations/:id/review',
           '/locations/:id/edit',
           '/locations/new',

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -274,22 +274,22 @@ const SettingsPage = ({ desktop }) => {
           <StyledListEntry
             rightIcons={<ChevronRight size="16" color={theme.blue} />}
             primaryText={'The project'}
-            onClick={() => history.push('/about/project')}
+            onClick={() => history.push('/about')}
           />
           <StyledListEntry
             rightIcons={<ChevronRight size="16" color={theme.blue} />}
             primaryText={'The data'}
-            onClick={() => history.push('/about/data')}
+            onClick={() => history.push('/data')}
           />
           <StyledListEntry
             rightIcons={<ChevronRight size="16" color={theme.blue} />}
             primaryText={'Sharing the harvest'}
-            onClick={() => history.push('/about/share')}
+            onClick={() => history.push('/sharing')}
           />
           <StyledListEntry
             rightIcons={<ChevronRight size="16" color={theme.blue} />}
             primaryText={'In the press'}
-            onClick={() => history.push('/about/press')}
+            onClick={() => history.push('/press')}
           />
         </>
       )}

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -106,14 +106,19 @@ const SettingsPage = ({ desktop }) => {
             {user ? (
               <>
                 <p>Logged in as {user.name || user.email}</p>
-                <Button secondary onClick={() => history.push('/account')}>
+                <Button secondary onClick={() => history.push('/users/edit')}>
                   View Account
                 </Button>
               </>
             ) : (
               <>
-                <Button onClick={() => history.push('/login')}>Login</Button>
-                <Button secondary onClick={() => history.push('/signup')}>
+                <Button onClick={() => history.push('/users/sign_in')}>
+                  Login
+                </Button>
+                <Button
+                  secondary
+                  onClick={() => history.push('/users/sign_up')}
+                >
                   Sign up
                 </Button>
               </>

--- a/src/components/table/ImportsTable.jsx
+++ b/src/components/table/ImportsTable.jsx
@@ -95,8 +95,8 @@ const ImportsTable = () => {
       persistTableHead
       onRowClicked={(row) => {
         history.push({
-          pathname: `/about/dataset/${row.id}`,
-          state: { fromPage: '/about/datasets' },
+          pathname: `/imports/${row.id}`,
+          state: { fromPage: '/data' },
         })
       }}
     />

--- a/src/utils/getInitialUrl.js
+++ b/src/utils/getInitialUrl.js
@@ -36,7 +36,7 @@ export const parseUrl = () => {
   const { pathname } = window.location
   const geocoordMatch = pathname.substring(pathname.indexOf('@'))
 
-  const isEntryPage = !!matchPath(pathname, '/entry/:id')
+  const isEntryPage = !!matchPath(pathname, '/locations/:id')
   const coords = getValidCoord(geocoordMatch)
 
   if (coords) {

--- a/src/utils/useRoutedTabs.js
+++ b/src/utils/useRoutedTabs.js
@@ -37,7 +37,7 @@ const useRoutedTabs = (tabPaths, defaultTabIndex = 0) => {
     if (
       // TODO: remove this edge case when refactoring Reach Tabs into NavLinks
       tabIndex === 0 &&
-      pathname.includes('/entry') &&
+      pathname.includes('/locations') &&
       state?.fromPage === '/list'
     ) {
       history.push(pathname, { state: { fromPage: '/map' } })


### PR DESCRIPTION
The following path changes are proposed for backwards compatibility with the existing website (and all the links in the wild to said website):

- /about/project -> /about
- /about/press -> /press
- /about/share -> /sharing
- /about/data -> /data + /datasets (combines both pages)
  Deprecated alternate paths /maps and /inventories are ignored.
- /about/dataset/:id -> /imports/:id
- /entry/:id -> /locations/:id
- /entry/new -> /locations/new
- /entry/edit -> /locations/edit
- /account -> /users/edit
- /login -> /users/sign_in
- /signup -> /users/sign_up
- /password -> /users/password
- /password/reset -> /users/password/new
- /password/set -> /users/password/edit (API update required)
- /confirmation/new -> /users/confirmation/new
- /confirmation -> /users/confirmation (API update required)
- /review/:id/edit -> /reviews/:id/edit

See #246.