### PR TITLE
Move construction of types tree later in the flow

### DIFF
--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -6,7 +6,7 @@ import styled from 'styled-components/macro'
 
 import { filtersChanged, selectionChanged } from '../../redux/filterSlice'
 import { useTypesById } from '../../redux/useTypesById'
-import { updateTreeCounts } from '../../utils/buildTypeSchema'
+import { constructTypesTreeForSelection } from '../../utils/buildTypeSchema'
 import Input from '../ui/Input'
 import { CheckboxFilters } from './CheckboxFilters'
 import FilterButtons from './FilterButtons'
@@ -86,25 +86,25 @@ const Filter = ({ isOpen }) => {
   const { typesById } = useTypesById()
   const filters = useSelector((state) => state.filter)
   const {
-    types,
     isLoading,
     countsById,
-    treeData,
+    allTypes,
+    types,
     childrenById,
     showOnlyOnMap,
     scientificNameById,
   } = filters
 
-  const treeDataWithUpdatedCounts = useMemo(
+  const typesTreeForSelection = useMemo(
     () =>
-      updateTreeCounts(
-        treeData,
+      constructTypesTreeForSelection(
+        allTypes,
         countsById,
         showOnlyOnMap,
         childrenById,
         scientificNameById,
       ),
-    [treeData, countsById, showOnlyOnMap, childrenById, scientificNameById],
+    [allTypes, countsById, showOnlyOnMap, childrenById, scientificNameById],
   )
 
   useLayoutEffect(() => {
@@ -154,16 +154,12 @@ const Filter = ({ isOpen }) => {
         </TreeFiltersContainer>
         {didMount.current ? (
           <RCTreeSelect
-            data={treeDataWithUpdatedCounts}
+            data={typesTreeForSelection}
             loading={isLoading}
             onChange={(selectedTypes) =>
-              dispatch(
-                selectionChanged(
-                  selectedTypes.filter((t) => !t.includes('root')),
-                ),
-              )
+              dispatch(selectionChanged(selectedTypes))
             }
-            checkedTypes={types}
+            types={types}
             searchValue={searchValue}
           />
         ) : (

--- a/src/components/filter/RCTreeSelect.js
+++ b/src/components/filter/RCTreeSelect.js
@@ -4,6 +4,7 @@ import TreeSelect from 'rc-tree-select'
 import { useState } from 'react'
 import styled from 'styled-components/macro'
 
+import { RC_ROOT_ID } from '../../utils/buildTypeSchema'
 import { ReactComponent as ArrowIcon } from './arrow.svg'
 
 const TreeSelectContainer = styled.div`
@@ -109,7 +110,7 @@ const TreeSelectContainer = styled.div`
   }
 `
 
-const RCTreeSelect = ({ data, onChange, checkedTypes, searchValue }) => {
+const RCTreeSelect = ({ data, onChange, types, searchValue }) => {
   // useState is necessary instead of useRef in order to restore the container ref whenever the tree re-renders
   const [treeSelectContainerRef, setTreeSelectContainerRef] = useState(null)
 
@@ -140,12 +141,13 @@ const RCTreeSelect = ({ data, onChange, checkedTypes, searchValue }) => {
             overflow: 'auto',
           }}
           treeData={data}
-          value={checkedTypes}
+          value={types}
           treeCheckable
           onChange={onChange}
           treeDataSimpleMode={{
-            id: 'value',
-            rootPId: 'null',
+            id: 'rcId',
+            pId: 'rcParentId',
+            rootPId: RC_ROOT_ID,
           }}
           treeNodeFilterProp="searchValue"
           open

--- a/src/redux/filterSlice.js
+++ b/src/redux/filterSlice.js
@@ -2,11 +2,8 @@ import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
 import { getTypeCounts } from '../utils/api'
 import {
-  buildTypeSchema,
   getChildrenById,
   getScientificNameById,
-  getTypesWithPendingCategory,
-  PENDING_ID,
 } from '../utils/buildTypeSchema'
 import { fetchAllTypes } from './miscSlice'
 import { selectParams } from './selectParams'
@@ -34,8 +31,8 @@ export const fetchFilterCounts = createAsyncThunk(
 export const filterSlice = createSlice({
   name: 'filter',
   initialState: {
+    allTypes: [],
     types: null,
-    treeData: [],
     childrenById: {},
     scientificNameById: {},
     muni: true,
@@ -72,19 +69,10 @@ export const filterSlice = createSlice({
     [updateSelection]: (state, action) => ({ ...state, ...action.payload }),
 
     [fetchAllTypes.fulfilled]: (state, action) => {
-      const typesWithPendingCategory = getTypesWithPendingCategory([
-        ...action.payload,
-        {
-          id: PENDING_ID,
-          parent_id: null,
-          name: 'Pending Review',
-        },
-      ])
-      const childrenById = getChildrenById(typesWithPendingCategory)
-      state.childrenById = childrenById
-      state.treeData = buildTypeSchema(typesWithPendingCategory, childrenById)
-      state.scientificNameById = getScientificNameById(action.payload)
+      state.allTypes = action.payload
       state.types = action.payload.map((t) => `${t.id}`)
+      state.childrenById = getChildrenById(action.payload)
+      state.scientificNameById = getScientificNameById(action.payload)
     },
   },
 })

--- a/src/utils/buildTypeSchema.js
+++ b/src/utils/buildTypeSchema.js
@@ -111,17 +111,14 @@ const constructTypesTreeForSelection = (
 
   typesForSelection.forEach((t) => {
     const { id, parent_id } = t
-    const isParentInSelection = idsOfParents[id]
+    const isParentInSelectionWithOwnValue = idsOfParents[id] && countsById[id]
     const hasParentInSelection = allIdsForSelection[parent_id]
-    const hasOwnCount = countsById[id]
-    if (isParentInSelection && hasOwnCount) {
-      // Add an extra checkbox
-      // (so the user can select just the less specifically annotated
-      // types as well as the whole selection)
+    if (isParentInSelectionWithOwnValue) {
+      // Allow the user to select just the less specifically annotated type
       typesAndParentsForSelection.push({
         ...t,
         count: countsById[id],
-        rcId: `extra-${id}`,
+        rcId: `extra-child-id-${id}`,
         value: `${id}`,
         rcParentId: `${id}`,
       })
@@ -130,7 +127,12 @@ const constructTypesTreeForSelection = (
       ...t,
       count: totalCountsById[id],
       rcId: `${id}`,
-      value: `${id}`,
+      value: isParentInSelectionWithOwnValue
+        ? // Use bogus value to avoid conflict warning
+          // the checkbox still affects the correct value, `${id}`,
+          // because it is the parent of child with that value
+          `extra-group-value-${id}`
+        : `${id}`,
       // The parent is the "Pending Review" if applicable,
       // or parent_id if we decided to display it,
       // or else a special "null" pId that makes it show up at top level

--- a/src/utils/buildTypeSchema.js
+++ b/src/utils/buildTypeSchema.js
@@ -85,17 +85,7 @@ const constructTypesTreeForSelection = (
   })
 
   const typesForSelection = showOnlyOnMap
-    ? allTypes.filter((t) => {
-        const { id } = t
-        const numChildrenForSelection = (childrenById[id] || []).filter(
-          (child_id) => totalCountsById[child_id],
-        ).length
-        const hasOwnCount = countsById[id]
-        const hasTotalCount = totalCountsById[id]
-
-        // If the type is on the map, or more than one of its descendants is on the map, keep it
-        return hasOwnCount || (hasTotalCount && numChildrenForSelection > 1)
-      })
+    ? allTypes.filter((t) => totalCountsById[t.id])
     : [...allTypes]
 
   const allIdsForSelection = {}


### PR DESCRIPTION
When we do this given a selection and counts,
we can make the tree look better by removing needless parents

New behaviour is to only keep the parents when there is branching under them Example 1:
/map/@34.63293829116424,-81.5339308198741,9z + search for Actinidia the 'issai' cultivar appears in its own checkbox
![Screenshot from 2024-05-24 12-03-39](https://github.com/falling-fruit/falling-fruit-web/assets/16976512/a1fc4a3b-0c82-43ad-a193-630ce1f77df5)

Example 2:
zoom in on Glasgow and look for Wild garlic, then zoom out eventually it goes under 'Onion' during zooming out (together with Three-cornered leek annotation)
![Screenshot from 2024-05-24 12-04-32](https://github.com/falling-fruit/falling-fruit-web/assets/16976512/e304b7d3-3d0a-4905-b41e-89a2dc8ce00d)
![Screenshot from 2024-05-24 12-04-44](https://github.com/falling-fruit/falling-fruit-web/assets/16976512/5c56e84a-59cf-440e-9eeb-bfb0219b2a54)

Behaviour about selecting the parent, and parents being duplicated to also just stand for less specific annotations, is as before

The 'Pending Review' nodes still always go under their own node with the same behaviour

Also refactor to use different property names in tree-select ( previous choices reused other variables,
  relied on null stringifying to 'null',
  and added a 'root' to some variables and not others)

Also, don't put the null parent into result of getChildrenById

Closes #311



