### PR TITLE
Only include bounds if available (draft PR)

### DIFF
--- a/src/redux/listSlice.js
+++ b/src/redux/listSlice.js
@@ -1,10 +1,13 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
 
 import { getLocations, getLocationsCount } from '../utils/api'
+import { parseUrl } from '../utils/getInitialUrl'
 import { setReducer, viewChange } from './mapSlice'
 import { searchView } from './searchView'
 import { selectParams } from './selectParams'
 import { updateSelection } from './updateSelection'
+
+const { _, ...initialView } = parseUrl()
 
 export const fetchListLocations = createAsyncThunk(
   'list/fetchListLocations',
@@ -30,7 +33,7 @@ export const listSlice = createSlice({
     isLoading: false,
     totalCount: null,
     offset: 0,
-    view: null, // Represents what view is used for the list
+    view: initialView,
     isViewSearched: false,
     shouldFetchNewLocations: false,
     updateOnMapMove: true,
@@ -59,6 +62,10 @@ export const listSlice = createSlice({
     [fetchListLocations.pending]: (state) => {
       state.shouldFetchNewLocations = false
       state.isLoading = true
+    },
+    [fetchListLocations.rejected]: (state) => {
+      // temporary aid for #347
+      console.log('fetchListLocations.rejected', state)
     },
     [fetchListLocations.fulfilled]: (state, action) => {
       const { extend, offset, locations, count } = action.payload

--- a/src/redux/selectParams.js
+++ b/src/redux/selectParams.js
@@ -32,7 +32,7 @@ export const selectParams = (state, extraParams = {}, isMap = true) => {
     types: types && types.join(','),
     muni,
     invasive,
-    ...convertBounds(view.bounds),
+    ...(view.bounds && convertBounds(view.bounds)),
     ...(!isMap && convertCenter(view.center)),
     ...extraParams,
   }


### PR DESCRIPTION
Addresses #347 

Not quite finished, because it returns a 400 from the API:
https://fallingfruit.org/api/0.3/locations/count?api_key=AKDJGHSD&muni=true&invasive=false&center=-0.9617529350012148,-90.95920155441307&limit=100&offset=0&photo=true
"Cannot read properties of undefined (reading 'split')"

The openapi.yml promises bounds to be optional, so this is technically a bug to be fixed in the api, but a different solution would be to also initialize the bounds, maybe based on the default zoom.