### PR TITLE
Add z-index so that the map remains pannable with the location drawer over it

### DIFF
--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -79,6 +79,7 @@ const MobileLayout = () => {
       <div
         style={{
           display: shouldDisplayMapPage(pathname) ? 'initial' : 'none',
+          zIndex: 1,
         }}
       >
         <MapPage />


### PR DESCRIPTION
I'm actually not sure why this works, but:
- I looked at the DOM of the location page http://localhost:3000/locations/1924358/@-0.970248495464574,-90.9548591091169,15z with a non-pannable map
- removed the drawer and noticed the map started to be pannable again
- I did zIndex:2, trying to make it go on top, and it worked
- then zIndex:1 also works, I'm guessing it just has to be defined

Closes #399 