### PR TITLE
Remove custom styling of unselected tab icons

### DIFF
--- a/src/components/ui/PageTabs.js
+++ b/src/components/ui/PageTabs.js
@@ -49,12 +49,6 @@ const PageTabs = styled(Tabs)`
         height: 24px;
       }
 
-      &:not([data-selected]) {
-        ${StyledIconBase} {
-          color: ${({ theme }) => theme.secondaryBackground};
-        }
-      }
-
       &[data-selected] {
         color: ${({ theme }) => theme.orange};
         border-top-color: ${({ theme }) => theme.orange};


### PR DESCRIPTION
I'm not sure why, but the List icon was the only icon affected by a custom color styling when unselected. Remove this style renders all of the tab icons the same (darker) color, which seems like an improvement.