### PR TITLE
Put state of current location/review in Redux

### DIFF
--- a/src/components/connect/ConnectLocation.js
+++ b/src/components/connect/ConnectLocation.js
@@ -1,0 +1,19 @@
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { fetchLocationData, setNewLocation } from '../../redux/locationSlice'
+
+const ConnectLocation = ({locationId}) => {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (locationId === 'new') {
+      dispatch(setNewLocation())
+    } else {
+      dispatch(fetchLocationData(locationId))
+    }
+  }, [dispatch, locationId])
+  return null
+}
+
+export default ConnectLocation

--- a/src/components/connect/ConnectReview.js
+++ b/src/components/connect/ConnectReview.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { fetchReviewData } from '../../redux/reviewSlice'
+
+const ConnectReview = ({reviewId}) => {
+  const dispatch = useDispatch()
+  useEffect(() => {
+    dispatch(fetchReviewData(reviewId))
+  }, [dispatch, reviewId])
+
+  return null
+}
+
+export default ConnectReview

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -1,0 +1,17 @@
+import { Route } from 'react-router-dom'
+
+import ConnectLocation from './ConnectLocation'
+import ConnectReview from './ConnectReview'
+
+const connectRoutes = [
+  <Route key="connect-location" path="/locations/:locationId">
+    {({ match }) =>
+      match && <ConnectLocation locationId={match.params.locationId} />
+    }
+  </Route>,
+  <Route key="connect-review" path="/reviews/:reviewId/edit">
+    {({ match }) => match && <ConnectReview reviewId={match.params.reviewId} />}
+  </Route>,
+]
+
+export default connectRoutes

--- a/src/components/desktop/DesktopLayout.js
+++ b/src/components/desktop/DesktopLayout.js
@@ -5,6 +5,7 @@ import styled from 'styled-components/macro'
 
 import aboutRoutes from '../about/aboutRoutes'
 import authRoutes from '../auth/authRoutes'
+import connectRoutes from '../connect/connectRoutes'
 import MapPage from '../map/MapPage'
 import Header from './Header'
 import SidePaneSwitch from './SidePaneSwitch'
@@ -52,6 +53,7 @@ const DesktopLayout = () => (
       {aboutRoutes}
       {authRoutes}
       <Route>
+        {connectRoutes}
         <WindowSize>
           {({ width: vw }) => (
             <StyledSplit

--- a/src/components/entry/EntryWrapper.js
+++ b/src/components/entry/EntryWrapper.js
@@ -1,46 +1,25 @@
 import { useEffect, useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
-import { Redirect, useParams } from 'react-router-dom'
-import { toast } from 'react-toastify'
+import { useSelector } from 'react-redux'
 
-import { updateEntryLocation } from '../../redux/mapSlice'
-import { getLocationById } from '../../utils/api'
 import Entry from './Entry'
 import EntryMobile from './EntryMobile'
 import EntryOverview from './EntryOverview'
 import EntryReviews from './EntryReviews'
 
 const EntryWrapper = ({ desktop }) => {
-  const locationData = useSelector((state) => state.map.location)
-  const dispatch = useDispatch()
+  const { location: locationData, isLoading } = useSelector(
+    (state) => state.location,
+  )
 
   const [reviews, setReviews] = useState()
-  const [isError, setIsError] = useState(false)
-  const [isLoading, setIsLoading] = useState(true)
   const [isLightboxOpen, setIsLightboxOpen] = useState(false)
   const [lightboxIndex, setLightboxIndex] = useState([0, 0])
-  const { locationId } = useParams()
 
   useEffect(() => {
-    async function fetchEntryData() {
-      setIsLoading(true)
-
-      try {
-        const locationData = await getLocationById(locationId, 'reviews')
-
-        dispatch(updateEntryLocation(locationData))
-        setReviews(locationData.reviews)
-        setIsLoading(false)
-      } catch {
-        toast.error(`Location #${locationId} not found`, {
-          autoClose: 5000,
-        })
-        setIsError(true)
-      }
+    if (locationData) {
+      setReviews(locationData.reviews)
     }
-
-    fetchEntryData()
-  }, [locationId, dispatch])
+  }, [locationData, setReviews])
 
   const addSubmittedReview = (submittedReview) => {
     setReviews((reviews) => [...reviews, submittedReview])
@@ -59,10 +38,6 @@ const EntryWrapper = ({ desktop }) => {
   )
 
   const EntryComponent = desktop ? Entry : EntryMobile
-
-  if (isError) {
-    return <Redirect to="/map" />
-  }
 
   return (
     <EntryComponent

--- a/src/components/form/EditLocation.js
+++ b/src/components/form/EditLocation.js
@@ -1,42 +1,21 @@
-import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
-import { toast } from 'react-toastify'
+import { useSelector } from 'react-redux'
 
-import { getLocationById } from '../../utils/api'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { Page } from '../entry/Entry'
 import { LocationForm, locationToForm } from './LocationForm'
 
 export const EditLocationForm = (props) => {
-  const { locationId } = useParams()
   const history = useAppHistory()
-  const [location, setLocation] = useState(null)
+  const { location, isLoading } = useSelector((state) => state.location)
 
-  useEffect(() => {
-    const loadFormData = async () => {
-      try {
-        const location = await getLocationById(locationId)
-        setLocation(location)
-      } catch (error) {
-        toast.error(`Location #${locationId} not found`)
-      }
-    }
-
-    loadFormData()
-  }, [locationId])
-
-  const handleSubmit = () => {
-    if (location) {
-      history.push(`/locations/${location.id}`)
-    }
-  }
-
-  return (
+  return isLoading ? (
+    <div>Loading...</div>
+  ) : (
     location && (
       <LocationForm
         initialValues={locationToForm(location)}
-        editingId={locationId}
-        onSubmit={handleSubmit}
+        editingId={location.id}
+        onSubmit={() => history.push(`/locations/${location.id}`)}
         {...props}
       />
     )

--- a/src/components/form/EditReview.js
+++ b/src/components/form/EditReview.js
@@ -1,50 +1,21 @@
-import { useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
-import { useParams } from 'react-router-dom'
-import { toast } from 'react-toastify'
+import { useSelector } from 'react-redux'
 
-import { rememberLocationIdForReviewId } from '../../redux/miscSlice'
-import { getReviewById } from '../../utils/api'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { Page } from '../entry/Entry'
 import { ReviewForm, reviewToForm } from './ReviewForm'
 
 export const EditReviewForm = (props) => {
-  const { reviewId } = useParams()
   const history = useAppHistory()
-  const dispatch = useDispatch()
-  const [review, setReview] = useState(null)
+  const { review, isLoading } = useSelector((state) => state.review)
 
-  useEffect(() => {
-    const loadFormData = async () => {
-      try {
-        const review = await getReviewById(reviewId)
-        dispatch(
-          rememberLocationIdForReviewId({
-            reviewId,
-            locationId: review.location_id,
-          }),
-        )
-        setReview(review)
-      } catch (error) {
-        toast.error(`Review #${reviewId} not found`)
-      }
-    }
-
-    loadFormData()
-  }, [reviewId, dispatch])
-
-  const afterSubmit = () => {
-    if (review) {
-      history.push(`/locations/${review.location_id}`)
-    }
-  }
-  return (
+  return isLoading ? (
+    <div>Loading...</div>
+  ) : (
     review && (
       <ReviewForm
         initialValues={{ review: reviewToForm(review) }}
-        editingId={reviewId}
-        onSubmit={afterSubmit}
+        editingId={review.id}
+        onSubmit={() => history.push(`/locations/${review.location_id}`)}
         {...props}
       />
     )

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -34,18 +34,16 @@ const MapPage = ({ isDesktop }) => {
   const reviewRouteMatch = useRouteMatch({
     path: '/reviews/:reviewId/edit',
   })
-  const locationIdsByReviewId = useSelector(
-    (state) => state.misc.locationIdsByReviewId,
-  )
+  const { review } = useSelector((state) => state.review)
+
   let locationId, isAddingLocation, isViewingLocation
   if (locationRouteMatch) {
     locationId = parseInt(locationRouteMatch.params.locationId)
     isAddingLocation = locationRouteMatch.params.locationId === 'new'
     isViewingLocation =
       locationRouteMatch.params.nextSegment?.indexOf('@') === 0
-  } else if (reviewRouteMatch) {
-    const reviewId = parseInt(reviewRouteMatch.params.reviewId)
-    locationId = locationIdsByReviewId[reviewId]
+  } else if (reviewRouteMatch && review) {
+    locationId = review.location_id
     isAddingLocation = false
     isViewingLocation = true
   }

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -8,6 +8,7 @@ import useRoutedTabs from '../../utils/useRoutedTabs'
 import aboutRoutes from '../about/aboutRoutes'
 import AccountPage from '../auth/AccountPage'
 import authRoutes from '../auth/authRoutes'
+import connectRoutes from '../connect/connectRoutes'
 import EntryWrapper from '../entry/EntryWrapper'
 import { EditLocationForm } from '../form/EditLocation'
 import { EditReviewForm } from '../form/EditReview'
@@ -84,6 +85,7 @@ const MobileLayout = () => {
       >
         <MapPage />
       </div>
+      {connectRoutes}
       <TabPanels>
         <TopBarSwitch />
         <Switch>

--- a/src/redux/locationSlice.js
+++ b/src/redux/locationSlice.js
@@ -1,0 +1,45 @@
+import { createAsyncThunk,createSlice } from '@reduxjs/toolkit'
+import { toast } from 'react-toastify'
+
+import { getLocationById } from '../utils/api'
+
+export const fetchLocationData = createAsyncThunk(
+  'locations/fetchLocationData',
+  async (locationId) => {
+    const locationData = await getLocationById(locationId, 'reviews')
+    return locationData
+  },
+)
+
+const locationSlice = createSlice({
+  name: 'location',
+  initialState: {
+    locationId: null,
+    isLoading: false,
+    location: null,
+  },
+  reducers: {
+    setNewLocation: (state) => {
+      state.locationId = 'new'
+      state.isLoading = false
+      state.location = null
+    },
+  },
+  extraReducers: {
+    [fetchLocationData.pending]: (state) => {
+      state.isLoading = true
+    },
+    [fetchLocationData.fulfilled]: (state, action) => {
+      state.isLoading = false
+      state.location = action.payload
+    },
+    [fetchLocationData.rejected]: (state, action) => {
+      state.isLoading = false
+      toast.error(`Error fetching location data: ${action.payload}`)
+    },
+  },
+})
+
+export const { setNewLocation } = locationSlice.actions
+
+export default locationSlice.reducer

--- a/src/redux/mapSlice.js
+++ b/src/redux/mapSlice.js
@@ -6,6 +6,7 @@ import { toast } from 'react-toastify'
 import { VISIBLE_CLUSTER_ZOOM_LIMIT } from '../constants/map'
 import { getClusters, getLocations } from '../utils/api'
 import { parseUrl } from '../utils/getInitialUrl'
+import { fetchLocationData } from './locationSlice'
 import { selectParams } from './selectParams'
 import { updateSelection } from './updateSelection'
 /**
@@ -72,23 +73,6 @@ export const mapSlice = createSlice({
     viewChange: setReducer('view'),
     setHoveredLocationId: setReducer('hoveredLocationId'),
     setStreetView: setReducer('streetView'),
-
-    updateEntryLocation: (state, action) => {
-      state.location = action.payload
-
-      if (state.isInitialEntry) {
-        const { lat, lng } = state.location
-
-        state.isInitialEntry = false
-        state.view = {
-          center: {
-            lat,
-            lng,
-          },
-          zoom: 16,
-        }
-      }
-    },
 
     startTrackingLocation: (state) => {
       state.locationRequested = true
@@ -227,6 +211,22 @@ export const mapSlice = createSlice({
       state.clusters = action.payload
       state.locations = []
       state.isLoading = false
+    },
+    [fetchLocationData.fulfilled]: (state, action) => {
+      state.location = action.payload
+
+      if (state.isInitialEntry) {
+        const { lat, lng } = state.location
+
+        state.isInitialEntry = false
+        state.view = {
+          center: {
+            lat,
+            lng,
+          },
+          zoom: 16,
+        }
+      }
     },
   },
 })

--- a/src/redux/miscSlice.js
+++ b/src/redux/miscSlice.js
@@ -12,15 +12,10 @@ export const miscSlice = createSlice({
   initialState: {
     typesById: {},
     isDesktop: null,
-    locationIdsByReviewId: {},
   },
   reducers: {
     layoutChange: (state, action) => {
       state.isDesktop = action.payload.isDesktop
-    },
-    rememberLocationIdForReviewId: (state, action) => {
-      const { reviewId, locationId } = action.payload
-      state.locationIdsByReviewId[reviewId] = locationId
     },
   },
   extraReducers: {
@@ -35,6 +30,6 @@ export const miscSlice = createSlice({
   },
 })
 
-export const { layoutChange, rememberLocationIdForReviewId } = miscSlice.actions
+export const { layoutChange } = miscSlice.actions
 
 export default miscSlice.reducer

--- a/src/redux/reviewSlice.js
+++ b/src/redux/reviewSlice.js
@@ -1,0 +1,36 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import { toast } from 'react-toastify'
+
+import { getReviewById } from '../utils/api'
+
+export const fetchReviewData = createAsyncThunk(
+  'reviews/fetchReviewData',
+  async (reviewId) => {
+    const reviewData = await getReviewById(reviewId)
+    return reviewData
+  },
+)
+
+const reviewSlice = createSlice({
+  name: 'review', 
+  initialState: {
+    reviewId: null,
+    isLoading: false,
+    review: null,
+  },
+  extraReducers: {
+    [fetchReviewData.pending]: (state) => {
+      state.isLoading = true
+    },
+    [fetchReviewData.fulfilled]: (state, action) => {
+      state.isLoading = false
+      state.review = action.payload
+    },
+    [fetchReviewData.rejected]: (state, action) => {
+      state.isLoading = false 
+      toast.error(`Error fetching review data: ${action.payload}`)
+    },
+  },
+})
+
+export default reviewSlice.reducer

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -4,8 +4,10 @@ import { createBrowserHistory } from 'history'
 import authReducer from './authSlice'
 import filterReducer from './filterSlice'
 import listReducer from './listSlice'
+import locationReducer from './locationSlice'
 import mapReducer from './mapSlice'
 import miscReducer, { fetchAllTypes } from './miscSlice'
+import reviewReducer from './reviewSlice'
 import settingsReducer from './settingsSlice'
 
 export const history = createBrowserHistory()
@@ -18,6 +20,8 @@ export const store = configureStore({
     settings: settingsReducer,
     auth: authReducer,
     misc: miscReducer,
+    location: locationReducer,
+    review: reviewReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ serializableCheck: false }),


### PR DESCRIPTION
The reducers are just in their simplest state - and will probably grow if we put more stuff there, like intermediate states of form or drawer state - and there aren't really any huge benefits from the PR by itself but it should help later. From the original points:

1. >updateEntryLocation in src/redux/mapSlice.js, whose job it is to resolve URLs without the @ like /locations/1989068 to /locations/1989068/@55.82696200000001,-4.260660999999999,16z , is called from src/components/entry/EntryWrapper.js, whose job it is to display the location. A smell, plus I realised now it comes with a small bug: /locations/1989068/edit/ is not resolved with the same @.

I checked we still do a redirect from a bare URL to the one with coordinates

2. > a "new location" marker is in the middle of the map and the map is made to move in the background, even on desktop where moving the marker would arguably be more intuitive

Opened new issue, #409


3. > there was no good way to add going back and forth between position and location screens for the PR to edit location position
Should be easier now!

4.  > having the location open, and then clicking "edit", results in doing the API call again for no particular reason
Fixed

5. > no place to store the state of location drawer
Should be easier to do now!