### PR TITLE
Do not reset bounds on resize + throttle map update

### DIFF
--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -1,0 +1,40 @@
+// source:
+// https://github.com/sindresorhus/throttleit/blob/main/index.js
+// it requires node 18 so paste it in
+function throttle(function_, wait) {
+  let timeoutId
+  let lastCallTime = 0
+
+  console.log(`Throttle function created with wait time: ${wait}ms`)
+
+  return function throttled(...arguments_) {
+    // eslint-disable-line func-names
+    if (timeoutId) {
+      console.log('Clearing timeout')
+      clearTimeout(timeoutId)
+      timeoutId = 0
+    }
+
+    const now = Date.now()
+    const timeSinceLastCall = now - lastCallTime
+    const delayForNextCall = wait - timeSinceLastCall
+
+    console.log(`Time since last call: ${timeSinceLastCall}ms`)
+    console.log(`Delay for next call: ${delayForNextCall}ms`)
+
+    if (delayForNextCall <= 0) {
+      console.log('Executing function immediately')
+      lastCallTime = now
+      function_.apply(this, arguments_)
+    } else {
+      console.log(`Scheduling function execution in ${delayForNextCall}ms`)
+      timeoutId = setTimeout(() => {
+        console.log('xxxxxxxxxxxxxxx Executing scheduled function')
+        lastCallTime = Date.now()
+        function_.apply(this, arguments_)
+      }, delayForNextCall)
+    }
+  }
+}
+
+module.exports = throttle

--- a/src/utils/throttle.js
+++ b/src/utils/throttle.js
@@ -5,31 +5,19 @@ function throttle(function_, wait) {
   let timeoutId
   let lastCallTime = 0
 
-  console.log(`Throttle function created with wait time: ${wait}ms`)
-
   return function throttled(...arguments_) {
     // eslint-disable-line func-names
-    if (timeoutId) {
-      console.log('Clearing timeout')
-      clearTimeout(timeoutId)
-      timeoutId = 0
-    }
+    clearTimeout(timeoutId)
 
     const now = Date.now()
     const timeSinceLastCall = now - lastCallTime
     const delayForNextCall = wait - timeSinceLastCall
 
-    console.log(`Time since last call: ${timeSinceLastCall}ms`)
-    console.log(`Delay for next call: ${delayForNextCall}ms`)
-
     if (delayForNextCall <= 0) {
-      console.log('Executing function immediately')
       lastCallTime = now
       function_.apply(this, arguments_)
     } else {
-      console.log(`Scheduling function execution in ${delayForNextCall}ms`)
       timeoutId = setTimeout(() => {
-        console.log('xxxxxxxxxxxxxxx Executing scheduled function')
         lastCallTime = Date.now()
         function_.apply(this, arguments_)
       }, delayForNextCall)


### PR DESCRIPTION
Closes #443.

Resetting bounds on resize was an argument to google-map-react, and probably made sense when the view was set through react, but now it's being set to the default view, which kind of ruins the mobile UX. Removed the argument.

Then I added a throttle. The first call happens immediately, but when there are lots of updates - e.g. someone messes around with a scrollbar or clicks really quickly - the calls happen no more frequently than once a second, with intermediate calls dropped.

I tested the throttle by putting logs in, moving the window around like a maniac, and observing that timeouts are cleared much more often than scheduled or delayed calls.
```
wbazant@wbazant-19-01:~/dev/falling-fruit-web$ ag xxx x.log
39:xxxxxxxxxxxxxxx Executing scheduled function throttle2.js:32
47:xxxxxxxxxxxxxxx Executing scheduled function throttle2.js:32
63:xxxxxxxxxxxxxxx Executing scheduled function throttle2.js:32
79:xxxxxxxxxxxxxxx Executing scheduled function throttle2.js:32
wbazant@wbazant-19-01:~/dev/falling-fruit-web$ ag Clear x.log
11:Clearing timeout throttle2.js:13
21:Clearing timeout throttle2.js:13
25:Clearing timeout throttle2.js:13
35:Clearing timeout throttle2.js:13
43:Clearing timeout throttle2.js:13
51:Clearing timeout throttle2.js:13
55:Clearing timeout throttle2.js:13
59:Clearing timeout throttle2.js:13
67:Clearing timeout throttle2.js:13
71:Clearing timeout throttle2.js:13
75:Clearing timeout throttle2.js:13
83:Clearing timeout throttle2.js:13
87:Clearing timeout throttle2.js:13
91:Clearing timeout throttle2.js:13
wbazant@wbazant-19-01:~/dev/falling-fruit-web$ ag immed x.log
4:Executing function immediately throttle2.js:26
14:Executing function immediately throttle2.js:26
28:Executing function immediately throttle2.js:26
```