### PR TITLE
zIndexes between drawer and filter

### DIFF
--- a/src/components/entry/EntryMobile.js
+++ b/src/components/entry/EntryMobile.js
@@ -16,6 +16,7 @@ import {
 import { useAppHistory } from '../../utils/useAppHistory'
 import DraggablePane from '../ui/DraggablePane'
 import { EntryTabs, Tab, TabList, TabPanel, TabPanels } from '../ui/EntryTabs'
+import { zIndex } from '../ui/GlobalStyle'
 import IconButton from '../ui/IconButton'
 import Carousel from './Carousel'
 import EntryOverview from './EntryOverview'
@@ -47,7 +48,7 @@ const RevealedFromUnderneath = styled.div`
       ${-progress * targetHeight}px
     );
     transition: transform 0.15s linear;
-    z-index: -10;
+    z-index: -1;
   `}
 `
 const WhitespacePlaceholder = styled.div`
@@ -75,7 +76,7 @@ const Buttons = styled.div`
   left: 0;
   right: 0;
   top: 0;
-  z-index: 12;
+  z-index: ${zIndex.topBar + 1};
   padding: 16px;
   display: flex;
   justify-content: space-between;
@@ -111,6 +112,9 @@ const EntryMobile = () => {
     isLoading,
     pane: { drawerFullyOpen, tabIndex, drawerDisabled },
   } = useSelector((state) => state.location)
+  const { isOpenInMobileLayout: filterOpen } = useSelector(
+    (state) => state.filter,
+  )
   const hasImages =
     reviews &&
     reviews.filter((review) => review.photos && review.photos.length > 0)
@@ -133,6 +137,7 @@ const EntryMobile = () => {
   return (
     <>
       <DraggablePane
+        displayOverTopBar={!filterOpen || drawerFullyOpen}
         topPositionHeight={hasImages ? ENTRY_IMAGE_HEIGHT : TOP_BAR_HEIGHT}
         middlePositionScreenRatio={0.7}
         position={drawerFullyOpen || drawerDisabled ? 'top' : 'middle'}

--- a/src/components/entry/LightboxMobile.js
+++ b/src/components/entry/LightboxMobile.js
@@ -70,7 +70,6 @@ const ExitButtonMobile = styled(ResetButton)`
   background: rgba(0, 0, 0, 0.65);
   border-radius: 50%;
   padding: 5px;
-  z-index: 10;
 `
 
 const ImageContainer = styled.div`

--- a/src/components/ui/DraggablePane.js
+++ b/src/components/ui/DraggablePane.js
@@ -7,6 +7,8 @@ import React, {
 } from 'react'
 import styled from 'styled-components/macro'
 
+import { zIndex } from '../ui/GlobalStyle'
+
 const PaneContainer = styled.div`
   position: fixed;
   left: 0;
@@ -17,7 +19,8 @@ const PaneContainer = styled.div`
   touch-action: ${(props) => (props.isMiddlePosition ? 'none' : 'auto')};
   max-width: 100%;
   height: 100%;
-  z-index: 11;
+  z-index: ${(props) =>
+    props.displayOverTopBar ? zIndex.topBar + 1 : zIndex.topBar - 1};
   transition: transform 0.3s linear;
   background: ${(props) => (props.hasImages ? 'white' : 'none')};
   padding-top: ${(props) => (props.hasImages ? '0' : '10px')};
@@ -48,6 +51,7 @@ const DraggablePane = ({
   updateProgress,
   hasImages,
   showMoveElement,
+  displayOverTopBar,
 }) => {
   const isMiddlePosition = position === POSITIONS.MIDDLE
   const paneRef = useRef(null)
@@ -225,6 +229,7 @@ const DraggablePane = ({
       hasImages={hasImages}
       showMoveElement={showMoveElement}
       isMiddlePosition={isMiddlePosition}
+      displayOverTopBar={displayOverTopBar}
     >
       <DragHandle showMoveElement={showMoveElement} />
       {children}


### PR DESCRIPTION
fully open drawer goes over open filter, but partially open drawer goes under open filter. Different resolution than proposed - we don't need to manage the filter being open/closed for the user, it's enough to display them properly.
![Screenshot from 2024-09-29 09-43-00](https://github.com/user-attachments/assets/454817a0-c654-4c41-ba4d-460b6869bfb8)

Closes #450. 