### PR TITLE
Use current view in /map in top ribbon

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import MainPage from './components/MainPage'
 import GlobalStyle, { theme } from './components/ui/GlobalStyle'
 import Toast from './components/ui/Toast'
 import { store } from './redux/store'
+import { pathWithCurrentView } from './utils/appUrl'
 import AuthInitializer from './utils/AuthInitializer'
 import { ConnectedBreakpoint, useIsDesktop } from './utils/useBreakpoint'
 import { useGoogleAnalytics } from './utils/useGoogleAnalytics'
@@ -27,7 +28,7 @@ const App = () => {
       <ThemeProvider theme={theme}>
         <Switch>
           <Route exact path="/">
-            <Redirect to="/map" />
+            <Redirect to={pathWithCurrentView('/map')} />
           </Route>
           <Route>
             <MainPage />

--- a/src/components/auth/ConfirmationResendPage.js
+++ b/src/components/auth/ConfirmationResendPage.js
@@ -5,6 +5,7 @@ import { Link, Redirect } from 'react-router-dom'
 import { toast } from 'react-toastify'
 
 import { requestConfirmUser } from '../../utils/api'
+import { pathWithCurrentView } from '../../utils/appUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { PageTemplate } from '../about/PageTemplate'
 import { Column } from './AuthWrappers'
@@ -19,7 +20,7 @@ const ConfirmationResendPage = () => {
 
   if (!isLoading && user) {
     toast.info('You are already signed in.')
-    return <Redirect to="/map" />
+    return <Redirect to={pathWithCurrentView('/map')} />
   }
 
   const handleSubmit = async (values) => {

--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -7,6 +7,7 @@ import { Link, NavLink, useLocation, useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { logout } from '../../redux/authSlice'
+import { pathWithCurrentView } from '../../utils/appUrl'
 import aboutRoutes from '../about/aboutRoutes'
 import Button from '../ui/Button'
 import ResetButton from '../ui/ResetButton'
@@ -221,14 +222,17 @@ const Header = () => {
 
   return (
     <StyledHeader>
-      <LogoLink to="/map">
+      <LogoLink to={pathWithCurrentView('/map')}>
         <img src="/logo_orange.svg" alt="Falling Fruit logo" />
       </LogoLink>
       <nav>
         <div style={{ marginRight: 'auto' }}>
           <ul>
             <li>
-              <NavLink to="/map" activeClassName="active">
+              <NavLink
+                to={pathWithCurrentView('/map')}
+                activeClassName="active"
+              >
                 {t('glossary.map')}
               </NavLink>
             </li>

--- a/src/components/desktop/SidePane.js
+++ b/src/components/desktop/SidePane.js
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
+import { pathWithCurrentView } from '../../utils/appUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import Entry from '../entry/Entry'
 import { EditLocationForm } from '../form/EditLocation'
@@ -155,7 +156,7 @@ const SidePane = () => {
               }
             </Route>
             <Route>
-              <Redirect to="/map" />
+              <Redirect to={pathWithCurrentView('/map')} />
             </Route>
           </Switch>
         </Route>


### PR DESCRIPTION
Closes #432 . Now clicking on the map link on desktop will take you to the current view, if in the URL, e.g. from /locations/new to /map will now work. Going to /about and back already worked, I think one of `src/components/connect` components does it.



Original proposal was:
> Restore map view and context of what is happening - e.g. viewing or editing the location.

Don't do the second part, it's confusing to go to a location after clicking on 'Map'.