### PR TITLE
Always wrap type title in accordion parent

### DIFF
--- a/src/components/entry/TypesHeader.js
+++ b/src/components/entry/TypesHeader.js
@@ -29,7 +29,9 @@ const TypesHeader = ({ types }) => (
           </TypesAccordionItem>
         )
       } else {
-        return typeTitle
+        return (
+          <TypesAccordionItem key={type.id}>{typeTitle}</TypesAccordionItem>
+        )
       }
     })}
   </TypesAccordion>


### PR DESCRIPTION
Fixes #462 by always wrapping title title in the same parent container, regardless of whether it also contains a link accordion or not.

For testing:
* http://localhost:3000/locations/1919933
* http://localhost:3000/locations/1734926