### PR TITLE
fix unexpected behavior of back button in side panel settings

### DIFF
--- a/src/components/desktop/SidePane.js
+++ b/src/components/desktop/SidePane.js
@@ -63,7 +63,7 @@ const SidePane = () => {
     event.stopPropagation()
     history.push('/map')
   }
-  const goBack = (event) => {
+  const _goBack = (event) => {
     event.stopPropagation()
     history.goBack()
   }
@@ -122,7 +122,7 @@ const SidePane = () => {
             </Route>
             <Route path="/settings">
               <StyledNavBack>
-                <BackButton onClick={goBack}>
+                <BackButton onClick={goToMap}>
                   <ArrowBack />
                   {t('back')}
                 </BackButton>


### PR DESCRIPTION
From desktop: if settings page is opened in side panel, and user clicks on different locations on the map, the back button on the settings page goes through the location history before finally closing the settings page. Instead, it should leave the map as-is and only close the settings page. This bug was because the settings page back button used goBack function in onClick, whereas other similar components were using goToMap, which has the desired effect. Updated back button to use goToMap.

Closes #484 