### PR TITLE
Enhancement/default types

### DIFF
--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -82,7 +82,9 @@ const Filter = () => {
             onSelectAllClick={() =>
               dispatch(
                 selectionChanged(
-                  typesAccess.selectableTypes().map((type) => type.id),
+                  typesAccess
+                    .selectableTypesWithCategories('forager', 'freegan')
+                    .map((type) => type.id),
                 ),
               )
             }

--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -82,9 +82,7 @@ const Filter = () => {
             onSelectAllClick={() =>
               dispatch(
                 selectionChanged(
-                  typesAccess
-                    .selectableTypesWithCategories('forager', 'freegan')
-                    .map((type) => type.id),
+                  typesAccess.selectableTypes().map((type) => type.id),
                 ),
               )
             }

--- a/src/components/filter/FilterIconButton.js
+++ b/src/components/filter/FilterIconButton.js
@@ -10,7 +10,8 @@ const FilterIconButton = (props) => {
 
   const isInitialized = !typesAccess.isEmpty && types !== null
   const isDefaultChoice =
-    types?.length === typesAccess.selectableTypes().length &&
+    types?.length ===
+      typesAccess.selectableTypesWithCategories('forager', 'freegan').length &&
     muni === true &&
     invasive === false
 

--- a/src/components/filter/FilterIconButton.js
+++ b/src/components/filter/FilterIconButton.js
@@ -9,9 +9,18 @@ const FilterIconButton = (props) => {
   const { typesAccess } = useSelector((state) => state.type)
 
   const isInitialized = !typesAccess.isEmpty && types !== null
+
+  const defaultSelectionSet = new Set(
+    typesAccess
+      .selectableTypesWithCategories('forager', 'freegan')
+      .map((t) => t.id),
+  )
+
+  const currentSelectionSet = new Set(types)
+
   const isDefaultChoice =
-    types?.length ===
-      typesAccess.selectableTypesWithCategories('forager', 'freegan').length &&
+    defaultSelectionSet.size === currentSelectionSet.size &&
+    [...defaultSelectionSet].every((id) => currentSelectionSet.has(id)) &&
     muni === true &&
     invasive === false
 

--- a/src/redux/filterSlice.js
+++ b/src/redux/filterSlice.js
@@ -80,7 +80,9 @@ export const filterSlice = createSlice({
 
     [fetchAndLocalizeTypes.fulfilled]: (state, action) => {
       const typesAccess = action.payload
-      state.types = typesAccess.selectableTypes().map((t) => t.id)
+      state.types = typesAccess
+        .selectableTypesWithCategories('forager', 'freegan')
+        .map((t) => t.id)
     },
   },
 })

--- a/src/utils/apiSchema.ts
+++ b/src/utils/apiSchema.ts
@@ -642,6 +642,8 @@ export interface components {
       taxonomic_rank?: number | null;
       /** Common names, starting with the preferred synonym, by language code (e.g. `en`) and optional region code (e.g. `en_us`). Currently, only `en` can be set. */
       common_names?: { [key: string]: string[] };
+      /**Categories associated with the type */
+      categories?: string[];
     };
     /** Type properties that can be submitted. At least one name (in `common_names.en` or `scientific_names`) is required. */
     SubmitType: components["schemas"]["BaseType"] & {

--- a/src/utils/localizedTypes.ts
+++ b/src/utils/localizedTypes.ts
@@ -147,6 +147,14 @@ export class TypesAccess {
       localize(newType, language),
     ])
   }
+
+  selectableTypesWithCategories(...categories: string[]): LocalizedType[] {
+    return this.localizedTypes.filter(
+      (t) =>
+        t.id !== PENDING_ID &&
+        t.categories.some((category) => categories.includes(category)),
+    )
+  }
 }
 
 const toDisplayOrder = (localizedTypes: LocalizedType[]) =>

--- a/src/utils/localizedTypes.ts
+++ b/src/utils/localizedTypes.ts
@@ -18,6 +18,7 @@ export type LocalizedType = {
   commonName: string
   taxonomicRank: number
   urls: { [url: string]: string }
+  categories: string[]
 }
 
 type TypeSelectMenuEntry = {
@@ -44,6 +45,7 @@ const localize = (type: SchemaType, language: string): LocalizedType => {
     commonName,
     taxonomicRank: type.taxonomic_rank || 0,
     urls: type.urls || {},
+    categories: type.categories || [],
   }
 }
 
@@ -168,6 +170,7 @@ export const typesAccessInLanguage = (
       commonName: 'Pending Review',
       taxonomicRank: 0,
       urls: {},
+      categories: [],
     })
   }
   return createTypesAccess(toDisplayOrder(localizedTypes))


### PR DESCRIPTION
Closes #467. After implementing the changes, I used the data response from the browser's network tab to verify that the default selected options include 'forager' or 'freegan' as categories using the find function. Unfortunately, I did not check all of them.

Let me know if you'd like further adjustments!

![image](https://github.com/user-attachments/assets/ecd41075-eb3c-4fc0-a46b-d0c1a12307af)
