### PR TITLE
Settings map icons visual improvements

### DIFF
--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -220,60 +220,72 @@ const SettingsPage = ({ desktop }) => {
           GoogleMapTypes.includes(settings.mapType)
             ? {}
             : {
-                opacity: '50%',
                 pointerEvents: 'none',
               }
         }
       >
-        <RadioTiles
-          options={[
-            {
-              label: t('side_menu.bicycle'),
-              value: 'BicyclingLayer',
-              image: GoogleBicycling,
-            },
-            {
-              label: t('side_menu.transit'),
-              value: 'TransitLayer',
-              image: GoogleTransit,
-            },
-          ]}
-          value={settings.mapLayers.length === 0 ? null : settings.mapLayers[0]}
-          onChange={(value) => {
-            if (value === settings.mapLayers[0]) {
-              value = null
-            }
-            dispatch(
-              updateSettings({
-                mapLayers: value ? [value] : [],
-              }),
-            )
-          }}
-        />
-        {[
-          {
-            field: 'showBusinesses',
-            label: t('poi'),
-          },
-        ].map(({ field, label }) => (
-          <LabeledRow
-            key={field}
-            left={
-              <Checkbox
-                id={field}
-                onClick={(e) =>
-                  dispatch(
-                    updateSettings({
-                      [field]: e.target.checked,
-                    }),
-                  )
+        <div
+          style={
+            GoogleMapTypes.includes(settings.mapType)
+              ? {}
+              : {
+                  opacity: '50%',
+                  filter: 'grayscale(50%)',
                 }
-                checked={settings[field]}
-              />
+          }
+        >
+          <RadioTiles
+            options={[
+              {
+                label: t('side_menu.bicycle'),
+                value: 'BicyclingLayer',
+                image: GoogleBicycling,
+              },
+              {
+                label: t('side_menu.transit'),
+                value: 'TransitLayer',
+                image: GoogleTransit,
+              },
+            ]}
+            value={
+              settings.mapLayers.length === 0 ? null : settings.mapLayers[0]
             }
-            label={<label htmlFor={field}>{label}</label>}
+            onChange={(value) => {
+              if (value === settings.mapLayers[0]) {
+                value = null
+              }
+              dispatch(
+                updateSettings({
+                  mapLayers: value ? [value] : [],
+                }),
+              )
+            }}
           />
-        ))}
+          {[
+            {
+              field: 'showBusinesses',
+              label: t('poi'),
+            },
+          ].map(({ field, label }) => (
+            <LabeledRow
+              key={field}
+              left={
+                <Checkbox
+                  id={field}
+                  onClick={(e) =>
+                    dispatch(
+                      updateSettings({
+                        [field]: e.target.checked,
+                      }),
+                    )
+                  }
+                  checked={settings[field]}
+                />
+              }
+              label={<label htmlFor={field}>{label}</label>}
+            />
+          ))}
+        </div>
       </div>
 
       <h5>OpenStreetMap</h5>

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -296,12 +296,8 @@ const SettingsPage = ({ desktop }) => {
           )
         }
       />
-      {settings.mapType in Attributions ? (
+      {settings.mapType in Attributions && (
         <Attribution>{Attributions[settings.mapType]}</Attribution>
-      ) : (
-        <Attribution>
-          <br />
-        </Attribution>
       )}
 
       <h3>{t('side_menu.regional')}</h3>

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -66,38 +66,32 @@ const GoogleMapTypes = ['roadmap', 'terrain', 'hybrid']
 const Attributions = {
   'osm-standard': (
     <>
-      ©{' '}
       <a
         href="https://openstreetmap.org/copyright"
         target="_blank"
         rel="noreferrer"
       >
-        OpenStreetMap
-      </a>{' '}
-      contributors
+        © OpenStreetMap contributors
+      </a>
     </>
   ),
   'osm-toner-lite': (
     <>
-      ©{' '}
       <a href="https://stadiamaps.com" target="_blank" rel="noreferrer">
-        Stadia Maps
+        © Stadia Maps
       </a>{' '}
-      ©{' '}
       <a href="https://stamen.com" target="_blank" rel="noreferrer">
-        Stamen Design
+        © Stamen Design
       </a>{' '}
-      ©{' '}
       <a href="https://openmaptiles.org" target="_blank" rel="noreferrer">
-        OpenMapTiles
+        © OpenMapTiles
       </a>{' '}
-      ©{' '}
       <a
         href="https://www.openstreetmap.org/copyright"
         target="_blank"
         rel="noreferrer"
       >
-        OpenStreetMap contributors
+        © OpenStreetMap contributors
       </a>
     </>
   ),
@@ -109,6 +103,7 @@ const Attribution = styled.p`
   a {
     color: inherit;
     text-decoration: inherit;
+    white-space: nowrap;
   }
 `
 

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -312,8 +312,12 @@ const SettingsPage = ({ desktop }) => {
           )
         }
       />
-      {settings.mapType in Attributions && (
+      {settings.mapType in Attributions ? (
         <Attribution>{Attributions[settings.mapType]}</Attribution>
+      ) : (
+        <Attribution>
+          <br />
+        </Attribution>
       )}
 
       <h3>{t('side_menu.regional')}</h3>

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -220,72 +220,61 @@ const SettingsPage = ({ desktop }) => {
           GoogleMapTypes.includes(settings.mapType)
             ? {}
             : {
+                opacity: '50%',
+                filter: 'grayscale(50%)',
                 pointerEvents: 'none',
               }
         }
       >
-        <div
-          style={
-            GoogleMapTypes.includes(settings.mapType)
-              ? {}
-              : {
-                  opacity: '50%',
-                  filter: 'grayscale(50%)',
-                }
-          }
-        >
-          <RadioTiles
-            options={[
-              {
-                label: t('side_menu.bicycle'),
-                value: 'BicyclingLayer',
-                image: GoogleBicycling,
-              },
-              {
-                label: t('side_menu.transit'),
-                value: 'TransitLayer',
-                image: GoogleTransit,
-              },
-            ]}
-            value={
-              settings.mapLayers.length === 0 ? null : settings.mapLayers[0]
-            }
-            onChange={(value) => {
-              if (value === settings.mapLayers[0]) {
-                value = null
-              }
-              dispatch(
-                updateSettings({
-                  mapLayers: value ? [value] : [],
-                }),
-              )
-            }}
-          />
-          {[
+        <RadioTiles
+          options={[
             {
-              field: 'showBusinesses',
-              label: t('poi'),
+              label: t('side_menu.bicycle'),
+              value: 'BicyclingLayer',
+              image: GoogleBicycling,
             },
-          ].map(({ field, label }) => (
-            <LabeledRow
-              key={field}
-              left={
-                <Checkbox
-                  id={field}
-                  onClick={(e) =>
-                    dispatch(
-                      updateSettings({
-                        [field]: e.target.checked,
-                      }),
-                    )
-                  }
-                  checked={settings[field]}
-                />
-              }
-              label={<label htmlFor={field}>{label}</label>}
-            />
-          ))}
-        </div>
+            {
+              label: t('side_menu.transit'),
+              value: 'TransitLayer',
+              image: GoogleTransit,
+            },
+          ]}
+          value={settings.mapLayers.length === 0 ? null : settings.mapLayers[0]}
+          onChange={(value) => {
+            if (value === settings.mapLayers[0]) {
+              value = null
+            }
+            dispatch(
+              updateSettings({
+                mapLayers: value ? [value] : [],
+              }),
+            )
+          }}
+        />
+        {[
+          {
+            field: 'showBusinesses',
+            label: t('poi'),
+          },
+        ].map(({ field, label }) => (
+          <LabeledRow
+            key={field}
+            left={
+              <Checkbox
+                id={field}
+                onClick={(e) =>
+                  dispatch(
+                    updateSettings({
+                      [field]: e.target.checked,
+                    }),
+                  )
+                }
+                checked={settings[field]}
+              />
+            }
+            label={<label htmlFor={field}>{label}</label>}
+          />
+        ))}
       </div>
 
       <h5>OpenStreetMap</h5>


### PR DESCRIPTION
I wanted to see if greying out the icons will make them look better, and then I had the change ready. Have a look at the suggestion! 

I got the grey out from
```
,,aider src/components/settings/SettingsPage.js -m "When GoogleMapTypes doesn't include a mapType and we lower the opacity, also mix in some grey to make the elements look more disabled. Make sure only the images get the grey and not the whole div"
```

Also, I like the attribution in settings - I would propose a bit of whitespace to the UI that the attribution can take up when it appears, instead of the page getting longer after a click. 