### PR TITLE
fix: Street View close button location (#498)

### DIFF
--- a/src/components/map/CloseStreetView.js
+++ b/src/components/map/CloseStreetView.js
@@ -26,7 +26,7 @@ const StreetViewUIWrapper = styled.div`
   position: absolute;
 
   @media ${({ theme }) => theme.device.mobile} {
-    top: 100px;
+    top: 40px;
   }
 `
 

--- a/src/components/map/CloseStreetView.js
+++ b/src/components/map/CloseStreetView.js
@@ -24,10 +24,6 @@ const StreetViewUIWrapper = styled.div`
   left: 20px;
   justify-content: space-between;
   position: absolute;
-
-  @media ${({ theme }) => theme.device.mobile} {
-    top: 40px;
-  }
 `
 
 const CloseStreetView = () => {

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -287,7 +287,14 @@ const MapPage = ({ isDesktop }) => {
       style={
         isDesktop
           ? { width: '100%', height: '100%', position: 'relative' }
-          : { width: '100%', position: 'fixed', bottom: '50px', top: '63px' }
+          : {
+              width: '100%',
+              position: 'absolute',
+              top: '48px',
+              bottom: '50px',
+              left: 0,
+              right: 0,
+            }
       }
     >
       {(mapIsLoading || locationIsLoading) && <BottomLeftLoadingIndicator />}

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -20,12 +20,10 @@ import Tabs from './Tabs'
 import TopBarSwitch from './TopBarSwitch'
 
 const shouldDisplayMapPage = (pathname) => {
-  // display the map for map endpoints
   if (matchPath(pathname, { path: '/map', exact: false, strict: false })) {
     return true
   }
 
-  // additionally, also display in the background for some location pages
   const match = matchPath(pathname, {
     path: [
       '/locations/:locationId/:nextSegment/:nextNextSegment',
@@ -35,13 +33,13 @@ const shouldDisplayMapPage = (pathname) => {
     exact: false,
     strict: false,
   })
+
   const isPlacingNewLocationMarker =
     match?.params.locationId === 'new' &&
     match?.params.nextSegment !== 'details'
 
   const locationId =
     match?.params.locationId && parseInt(match.params.locationId)
-  // distinguish viewing a location from having it displayed during e.g. editing or review
   const isViewingLocation =
     locationId && match.params.nextSegment?.indexOf('@') === 0
 
@@ -60,6 +58,7 @@ const shouldDisplayMapPage = (pathname) => {
     isViewingPanorama
   )
 }
+
 const MobileLayout = () => {
   const streetView = useSelector((state) => state.location.streetViewOpen)
   const { pathname } = useLocation()
@@ -73,9 +72,15 @@ const MobileLayout = () => {
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
         />
       </Helmet>
+      <TopBarSwitch />
       <div
         style={{
-          display: shouldDisplayMapPage(pathname) ? 'initial' : 'none',
+          display: shouldDisplayMapPage(pathname) ? 'block' : 'none',
+          position: 'absolute',
+          top: '30px',
+          bottom: '0px',
+          left: 0,
+          right: 0,
           zIndex: 1,
         }}
       >
@@ -83,7 +88,6 @@ const MobileLayout = () => {
       </div>
       {connectRoutes}
       <TabPanels style={{ paddingBottom: '50px' }}>
-        <TopBarSwitch />
         <Switch>
           {aboutRoutes}
           {authRoutes}

--- a/src/components/ui/TopBar.js
+++ b/src/components/ui/TopBar.js
@@ -2,7 +2,6 @@ import styled from 'styled-components/macro'
 
 import { zIndex } from './GlobalStyle'
 
-// 80px height unless menu selections are visible
 const TopBar = styled.div`
   position: absolute;
   left: 0;
@@ -13,7 +12,7 @@ const TopBar = styled.div`
   filter: drop-shadow(0px -1px 8px ${({ theme }) => theme.shadow});
   padding: 16px;
   min-height: 48px;
-  border-radius: ${(props) => (props.rectangular ? '0' : '0 0 1.5em 1.5em')};
+  border-radius: 0;
   transition: border-radius 0.2s ease-out-in;
 `
 


### PR DESCRIPTION
### Happy Hacktoberfest! 
This issue fixes the top padding issue of the Google Street View close button. Sort of just a magic number solution, but it looks correct now.

Closes #498 