### PR TITLE
fix: unstable height of top bar (#507)

### DIFF
--- a/src/components/search/Search.js
+++ b/src/components/search/Search.js
@@ -213,33 +213,35 @@ const Search = (props) => {
           />
         )}
       </SearchBarContainer>
-      <StyledComboboxPopover portal={false}>
-        <ComboboxList>
-          {suggestionsList.map((suggestion) => {
-            const {
-              place_id,
-              description,
-              structured_formatting: { main_text, secondary_text },
-            } = suggestion
+      {suggestionsList.length > 0 && (
+        <StyledComboboxPopover portal={false}>
+          <ComboboxList>
+            {suggestionsList.map((suggestion) => {
+              const {
+                place_id,
+                description,
+                structured_formatting: { main_text, secondary_text },
+              } = suggestion
 
-            // Allow handleSelect to access the place id (see useRef above)
-            descriptionToPlaceId.current[description] = place_id
+              // Allow handleSelect to access the place id (see useRef above)
+              descriptionToPlaceId.current[description] = place_id
 
-            return (
-              <ComboboxOption
-                as={SearchEntry}
-                key={place_id}
-                value={description}
-                isCurrentLocation={
-                  description === selectedPlace?.location.description
-                }
-              >
-                {[main_text, secondary_text]}
-              </ComboboxOption>
-            )
-          })}
-        </ComboboxList>
-      </StyledComboboxPopover>
+              return (
+                <ComboboxOption
+                  as={SearchEntry}
+                  key={place_id}
+                  value={description}
+                  isCurrentLocation={
+                    description === selectedPlace?.location.description
+                  }
+                >
+                  {[main_text, secondary_text]}
+                </ComboboxOption>
+              )
+            })}
+          </ComboboxList>
+        </StyledComboboxPopover>
+      )}
     </Combobox>
   )
 }


### PR DESCRIPTION
This PR fixes the issue of having an empty suggestions list pop-up (which is a result of #501) when you focus on the search bar. 

Closes #507