### PR TITLE
Make 'Add location' button more prominent

### DIFF
--- a/src/components/desktop/MainSidePane.js
+++ b/src/components/desktop/MainSidePane.js
@@ -38,7 +38,6 @@ const MainPane = () => {
       <Search />
       <FilterWrapper />
       <AddLocationButton
-        secondary
         greyedOut={!isZoomSufficient}
         onClick={handleAddLocation}
       >

--- a/src/components/desktop/MainSidePane.js
+++ b/src/components/desktop/MainSidePane.js
@@ -14,7 +14,6 @@ const AddLocationButton = styled(Button)`
   padding: 15px 0;
   opacity: ${({ greyedOut }) => (greyedOut ? '0.5' : '1')};
   cursor: ${({ greyedOut }) => (greyedOut ? 'help' : 'pointer')};
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 `
 
 const MainPane = () => {

--- a/src/components/desktop/MainSidePane.js
+++ b/src/components/desktop/MainSidePane.js
@@ -15,7 +15,6 @@ const AddLocationButton = styled(Button)`
   opacity: ${({ greyedOut }) => (greyedOut ? '0.5' : '1')};
   cursor: ${({ greyedOut }) => (greyedOut ? 'help' : 'pointer')};
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  border: 2px solid white;
 `
 
 const MainPane = () => {


### PR DESCRIPTION
- Restored standard orange button styling used across the app.
- Maintained the same behavior when the button is disabled.

Closes #511