### PR TITLE
Make Fruiting status dropdown not searchable

### DIFF
--- a/src/components/form/ReviewForm.js
+++ b/src/components/form/ReviewForm.js
@@ -64,6 +64,7 @@ export const ReviewStep = ({ standalone, hasHeading = true }) => (
       label="Fruiting status"
       name="review.fruiting"
       options={FRUITING_OPTIONS}
+      isSearchable={false}
       isClearable
     />
 


### PR DESCRIPTION
- Aligned behavior with the location access dropdown.
- Prevented the dropdown from triggering the keyboard on mobile.

Closes #499 