### PR TITLE
#513 Fix bug. Review not shown after adding new location with review

### DIFF
--- a/src/redux/locationSlice.js
+++ b/src/redux/locationSlice.js
@@ -239,7 +239,7 @@ const locationSlice = createSlice({
          * New location added
          */
         state.location = action.payload
-        state.reviews = []
+        state.reviews = action.payload.reviews || []
         state.locationId = parseInt(action.payload.id)
       }
       state.isLoading = false


### PR DESCRIPTION
Updated the reducer to correctly handle the `reviews` field, ensuring it retains or updates submitted review instead of defaulting to empty array

Closes #513 