### PR TITLE
Calculate viewport bounds when searching for a place

### DIFF
--- a/docs/map-view-redux.md
+++ b/docs/map-view-redux.md
@@ -41,7 +41,7 @@ Usage:
 1. **Page Loads**
    1. Default or URL-parsed center and zoom are passed.
    2. `GoogleMapReact` calls `onChange` to provide map bounds.
-   3. `MapPage` dispatches `viewChangeAndFetch` with the new view:
+   3. `MapPage` dispatches actions with the new view:
       - Updates URL.
       - Stops tracking geolocation if the user moved too far.
       - Fetches filter counts if the filter is open.

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -12,7 +12,7 @@ import {
 import { fetchFilterCounts } from '../../redux/filterSlice'
 import { updatePosition } from '../../redux/locationSlice'
 import { setGoogle } from '../../redux/mapSlice'
-import { fetchLocations, viewChangeAndFetch } from '../../redux/viewChange'
+import { fetchLocations } from '../../redux/viewChange'
 import { updateLastMapView } from '../../redux/viewportSlice'
 import { bootstrapURLKeys } from '../../utils/bootstrapURLKeys'
 import throttle from '../../utils/throttle'
@@ -120,8 +120,9 @@ const makeHandleViewChange = (dispatch, googleMap, history) => (_) => {
     width: googleMap.getDiv().offsetWidth,
     height: googleMap.getDiv().offsetHeight,
   }
-  dispatch(viewChangeAndFetch(newView))
   dispatch(updateLastMapView(newView))
+  dispatch(fetchLocations())
+  dispatch(fetchFilterCounts())
   history.changeView(newView)
 }
 

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -117,6 +117,8 @@ const makeHandleViewChange = (dispatch, googleMap, history) => (_) => {
     center: { lat: center.lat(), lng: center.lng() },
     zoom: googleMap.getZoom(),
     bounds: googleMap.getBounds().toJSON(),
+    width: googleMap.getDiv().offsetWidth,
+    height: googleMap.getDiv().offsetHeight,
   }
   dispatch(viewChangeAndFetch(newView))
   dispatch(updateLastMapView(newView))
@@ -222,6 +224,8 @@ const MapPage = ({ isDesktop }) => {
       center: { lat: center.lat(), lng: center.lng() },
       zoom: map.getZoom(),
       bounds: map.getBounds().toJSON(),
+      width: map.getDiv().offsetWidth,
+      height: map.getDiv().offsetHeight,
     }
     dispatch(updateLastMapView(initialView))
     dispatch(fetchLocations())

--- a/src/components/search/Search.js
+++ b/src/components/search/Search.js
@@ -109,6 +109,7 @@ const Search = (props) => {
   })
 
   const { googleMap } = useSelector((state) => state.map)
+  const { lastMapView } = useSelector((state) => state.viewport)
 
   const coordinatesResultOrNull = getCoordinatesResult(value)
   const suggestionsList = coordinatesResultOrNull
@@ -160,6 +161,7 @@ const Search = (props) => {
       const placeBounds = await getPlaceBounds(
         description,
         descriptionToPlaceId.current[description],
+        lastMapView,
       )
       dispatch(selectPlace({ place: placeBounds }))
     }

--- a/src/components/search/Search.js
+++ b/src/components/search/Search.js
@@ -154,7 +154,7 @@ const Search = (props) => {
       const longitude = Number(description.split(',')[1])
       dispatch(
         selectPlace({
-          place: getZoomedInView(latitude, longitude),
+          place: getZoomedInView(latitude, longitude, lastMapView),
         }),
       )
     } else {

--- a/src/redux/mapSlice.js
+++ b/src/redux/mapSlice.js
@@ -9,21 +9,6 @@ import { selectPlace } from './placeSlice'
 import { selectParams } from './selectParams'
 import { updateSelection } from './updateSelection'
 
-// Helper function to calculate distance between two points
-const calculateDistance = (lat1, lon1, lat2, lon2) => {
-  const R = 6371 // Radius of the Earth in kilometers
-  const dLat = ((lat2 - lat1) * Math.PI) / 180
-  const dLon = ((lon2 - lon1) * Math.PI) / 180
-  const a =
-    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
-    Math.cos((lat1 * Math.PI) / 180) *
-      Math.cos((lat2 * Math.PI) / 180) *
-      Math.sin(dLon / 2) *
-      Math.sin(dLon / 2)
-  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
-  return R * c // Distance in kilometers
-}
-
 const MIN_TRACKING_ZOOM = 16
 
 export const fetchMapLocations = createAsyncThunk(
@@ -34,6 +19,7 @@ export const fetchMapLocations = createAsyncThunk(
     const { lastMapView } = state.viewport
     if (lastMapView) {
       const { bounds, zoom, center: _ } = lastMapView
+      console.log(zoom, bounds)
       return await getLocations(
         selectParams(
           { types, muni, invasive, bounds, zoom, center: undefined },
@@ -168,84 +154,8 @@ export const mapSlice = createSlice({
       }
     },
     [selectPlace]: (state, action) => {
-      const { ne, sw } = action.payload.place.viewport
-      const maps = state.getGoogleMaps()
-      const bounds = new maps.LatLngBounds(
-        { lat: sw.lat, lng: sw.lng },
-        { lat: ne.lat, lng: ne.lng },
-      )
-
-      // 1. Remember the initial view
-      const initialView = {
-        center: state.googleMap.getCenter().toJSON(),
-        zoom: state.googleMap.getZoom(),
-      }
-
-      // 2. Test newFallback
-      const newFallback = action.payload.place.newFallback.view
-      state.googleMap.setCenter(newFallback.center)
-      state.googleMap.setZoom(newFallback.zoom)
-      const newFallbackResult = {
-        center: state.googleMap.getCenter().toJSON(),
-        zoom: state.googleMap.getZoom(),
-      }
-
-      // Reset to initial view
-      state.googleMap.setCenter(initialView.center)
-      state.googleMap.setZoom(initialView.zoom)
-
-      // 3. Test oldFallback
-      const oldFallback = action.payload.place.oldFallback.view
-      state.googleMap.setCenter(oldFallback.center)
-      state.googleMap.setZoom(oldFallback.zoom)
-      const oldFallbackResult = {
-        center: state.googleMap.getCenter().toJSON(),
-        zoom: state.googleMap.getZoom(),
-      }
-
-      // Reset to initial view
-      state.googleMap.setCenter(initialView.center)
-      state.googleMap.setZoom(initialView.zoom)
-
-      // 4. Test fitBounds
-      state.googleMap.fitBounds(bounds)
-      const fitBoundsResult = {
-        center: state.googleMap.getCenter().toJSON(),
-        zoom: state.googleMap.getZoom(),
-      }
-
-      // 5. Calculate distances between centers and log results
-      const newToOldDistance = calculateDistance(
-        newFallbackResult.center.lat,
-        newFallbackResult.center.lng,
-        oldFallbackResult.center.lat,
-        oldFallbackResult.center.lng,
-      )
-      const newToFitBoundsDistance = calculateDistance(
-        newFallbackResult.center.lat,
-        newFallbackResult.center.lng,
-        fitBoundsResult.center.lat,
-        fitBoundsResult.center.lng,
-      )
-      const oldToFitBoundsDistance = calculateDistance(
-        oldFallbackResult.center.lat,
-        oldFallbackResult.center.lng,
-        fitBoundsResult.center.lat,
-        fitBoundsResult.center.lng,
-      )
-
-      console.log({
-        ...newFallbackResult,
-        distanceToOldFallback: `${newToOldDistance.toFixed(6)} km`,
-        distanceToFitBounds: `${newToFitBoundsDistance.toFixed(6)} km`,
-        zoomDiffOldFallback: newFallbackResult.zoom - oldFallbackResult.zoom,
-        zoomDiffFitBounds: newFallbackResult.zoom - fitBoundsResult.zoom,
-        oldFallbackResult,
-        oldToFitBoundsDistance,
-        fitBoundsResult,
-      })
-
-      // Keep the fitBounds result as the final view
+      state.googleMap.setCenter(action.payload.place.view.center)
+      state.googleMap.setZoom(action.payload.place.view.zoom)
     },
   },
 })

--- a/src/redux/mapSlice.js
+++ b/src/redux/mapSlice.js
@@ -19,7 +19,6 @@ export const fetchMapLocations = createAsyncThunk(
     const { lastMapView } = state.viewport
     if (lastMapView) {
       const { bounds, zoom, center: _ } = lastMapView
-      console.log(zoom, bounds)
       return await getLocations(
         selectParams(
           { types, muni, invasive, bounds, zoom, center: undefined },

--- a/src/redux/viewChange.js
+++ b/src/redux/viewChange.js
@@ -2,7 +2,6 @@ import { VISIBLE_CLUSTER_ZOOM_LIMIT } from '../constants/map'
 import { fetchFilterCounts } from './filterSlice'
 import { fetchMapClusters, fetchMapLocations } from './mapSlice'
 import { updateSelection } from './updateSelection'
-import { updateLastMapView } from './viewportSlice'
 
 const getIsShowingClusters = (state) => {
   const map = state.map.googleMap
@@ -22,11 +21,6 @@ export const fetchLocations = () => (dispatch, getState) => {
   }
 }
 
-export const viewChangeAndFetch = (newView) => (dispatch) => {
-  dispatch(updateLastMapView(newView))
-  dispatch(fetchLocations())
-  dispatch(fetchFilterCounts())
-}
 export const filtersChanged = (filters) => (dispatch) => {
   dispatch(updateSelection(filters))
   dispatch(fetchFilterCounts())

--- a/src/redux/viewportSlice.js
+++ b/src/redux/viewportSlice.js
@@ -1,5 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 
+import { selectPlace } from './placeSlice'
+
 export const viewportSlice = createSlice({
   name: 'viewport',
   initialState: {
@@ -7,7 +9,18 @@ export const viewportSlice = createSlice({
   },
   reducers: {
     updateLastMapView: (state, action) => {
-      state.lastMapView = action.payload
+      if (action.payload.width > 0 && action.payload.height > 0) {
+        state.lastMapView = action.payload
+      }
+    },
+  },
+  extraReducers: {
+    [selectPlace]: (state, action) => {
+      state.lastMapView = {
+        height: state.lastMapView.height,
+        width: state.lastMapView.width,
+        ...action.payload.place.view,
+      }
     },
   },
 })

--- a/src/utils/viewportBounds.js
+++ b/src/utils/viewportBounds.js
@@ -16,13 +16,36 @@ export const getZoomedInView = (locationLat, locationLng) =>
     },
   })
 
-export const getPlaceBounds = async (description, placeId) => {
+export const getPlaceBoundsOld = async (description, placeId, lastMapView) => {
   const results = await getGeocode({ placeId })
   const {
     geometry: { viewport, location },
   } = results[0]
 
   const [ne, sw] = [viewport.getNorthEast(), viewport.getSouthWest()]
+
+  const proposedZoom = getZoom(
+    ne.lat(),
+    ne.lng(),
+    sw.lat(),
+    sw.lng(),
+    lastMapView.height,
+    lastMapView.width,
+  )
+  const proposedCenter = {
+    lat: (ne.lat() + sw.lat()) / 2,
+    lng: (ne.lng() + sw.lng()) / 2,
+  }
+
+  const proposedBounds = getProposedBounds(
+    proposedCenter,
+    proposedZoom,
+    lastMapView.width,
+    lastMapView.height,
+  )
+
+  console.log({ proposedZoom, proposedCenter, proposedBounds })
+
   return {
     location: {
       lat: location.lat(),
@@ -33,5 +56,244 @@ export const getPlaceBounds = async (description, placeId) => {
       ne: { lat: ne.lat(), lng: ne.lng() },
       sw: { lat: sw.lat(), lng: sw.lng() },
     },
+    fallbackView: {
+      zoom: proposedZoom,
+      center: proposedCenter,
+      bounds: proposedBounds,
+      width: lastMapView.width,
+      height: lastMapView.height,
+    },
   }
+}
+
+// AI generated
+const WORLD_DIM = { height: 256, width: 256 } // tile size
+const ZOOM_MAX = 21 // max zoom level in Google Maps
+
+const latRad = (lat) => {
+  const sin = Math.sin((lat * Math.PI) / 180)
+  const radX2 = Math.log((1 + sin) / (1 - sin)) / 2
+  return Math.max(Math.min(radX2, Math.PI), -Math.PI) / 2
+}
+
+const getZoom = (neLat, neLng, swLat, swLng, height, width) => {
+  console.log('getZoom inputs:', { neLat, neLng, swLat, swLng, height, width })
+
+  // Ensure inputs are numbers and not undefined
+  if (
+    [neLat, neLng, swLat, swLng, height, width].some(
+      (val) => typeof val !== 'number' || isNaN(val),
+    )
+  ) {
+    console.error('Invalid inputs to getZoom')
+    return 12 // Default zoom level
+  }
+
+  // Calculate latitude fraction
+  const neLatRad = latRad(neLat)
+  const swLatRad = latRad(swLat)
+  const latFraction = Math.abs(neLatRad - swLatRad) / Math.PI
+  console.log('Lat calculations:', { neLatRad, swLatRad, latFraction })
+
+  // Calculate longitude fraction
+  let lngDiff = neLng - swLng
+  // Normalize longitude difference
+  if (lngDiff < -180) {lngDiff += 360}
+  if (lngDiff > 180) {lngDiff -= 360}
+  const lngFraction = Math.abs(lngDiff) / 360
+  console.log('Lng calculations:', { lngDiff, lngFraction })
+
+  // Prevent division by zero
+  if (latFraction === 0 || lngFraction === 0) {
+    console.warn('Zero fraction detected')
+    return 12 // Default zoom level
+  }
+
+  const latZoom = Math.floor(
+    Math.log(height / WORLD_DIM.height / latFraction) / Math.LN2,
+  )
+  const lngZoom = Math.floor(
+    Math.log(width / WORLD_DIM.width / lngFraction) / Math.LN2,
+  )
+
+  console.log('Zoom calculations:', { latZoom, lngZoom })
+
+  const finalZoom = Math.min(Math.max(1, Math.min(latZoom, lngZoom)), ZOOM_MAX)
+  console.log('Final zoom:', finalZoom)
+
+  return finalZoom
+}
+
+const getProposedBounds = (center, zoom, width, height) => {
+  const scale = Math.pow(2, zoom)
+  const worldCoordinateCenter = project(center)
+
+  const pixelCoordinate = {
+    x: worldCoordinateCenter.x * scale,
+    y: worldCoordinateCenter.y * scale,
+  }
+
+  const halfWidthInPixels = width / 2
+  const halfHeightInPixels = height / 2
+
+  const newNorthEast = unproject({
+    x: (pixelCoordinate.x + halfWidthInPixels) / scale,
+    y: (pixelCoordinate.y - halfHeightInPixels) / scale,
+  })
+
+  const newSouthWest = unproject({
+    x: (pixelCoordinate.x - halfWidthInPixels) / scale,
+    y: (pixelCoordinate.y + halfHeightInPixels) / scale,
+  })
+
+  return {
+    ne: { lat: newNorthEast.lat, lng: newNorthEast.lng },
+    sw: { lat: newSouthWest.lat, lng: newSouthWest.lng },
+  }
+}
+
+const project = ({ lat, lng }) => {
+  const TILE_SIZE = 256
+  const siny = Math.sin((lat * Math.PI) / 180)
+  const x = TILE_SIZE * (0.5 + lng / 360)
+  const y =
+    TILE_SIZE * (0.5 - Math.log((1 + siny) / (1 - siny)) / (4 * Math.PI))
+  return { x, y }
+}
+
+const unproject = ({ x, y }) => {
+  const TILE_SIZE = 256
+  const lng = (x / TILE_SIZE - 0.5) * 360
+  const latRadians = Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / TILE_SIZE)))
+  const lat = latRadians * (180 / Math.PI)
+  return { lat, lng }
+}
+
+const EARTH_RADIUS = 6378137
+const MAX_LATITUDE = 85.0511287798
+
+export const getPlaceBounds = async (description, placeId, lastMapView) => {
+  const results = await getGeocode({ placeId })
+  const {
+    geometry: { viewport, location },
+  } = results[0]
+
+  const [ne, sw] = [viewport.getNorthEast(), viewport.getSouthWest()]
+
+  const mercatorNE = latLngToMercator(ne.lat(), ne.lng())
+  const mercatorSW = latLngToMercator(sw.lat(), sw.lng())
+
+  const aspectRatio = lastMapView.width / lastMapView.height
+  const padding = 0.1 // 10% padding
+
+  const mercatorWidth = mercatorNE.x - mercatorSW.x
+  const mercatorHeight = mercatorSW.y - mercatorNE.y
+
+  let adjustedMercatorWidth = mercatorWidth * (1 + padding)
+  let adjustedMercatorHeight = mercatorHeight * (1 + padding)
+
+  if (adjustedMercatorWidth / adjustedMercatorHeight > aspectRatio) {
+    adjustedMercatorHeight = adjustedMercatorWidth / aspectRatio
+  } else {
+    adjustedMercatorWidth = adjustedMercatorHeight * aspectRatio
+  }
+
+  const mercatorCenter = {
+    x: (mercatorNE.x + mercatorSW.x) / 2,
+    y: (mercatorNE.y + mercatorSW.y) / 2,
+  }
+
+  const adjustedMercatorNE = {
+    x: mercatorCenter.x + adjustedMercatorWidth / 2,
+    y: mercatorCenter.y - adjustedMercatorHeight / 2,
+  }
+
+  const adjustedMercatorSW = {
+    x: mercatorCenter.x - adjustedMercatorWidth / 2,
+    y: mercatorCenter.y + adjustedMercatorHeight / 2,
+  }
+
+  const adjustedNE = mercatorToLatLng(
+    adjustedMercatorNE.x,
+    adjustedMercatorNE.y,
+  )
+  const adjustedSW = mercatorToLatLng(
+    adjustedMercatorSW.x,
+    adjustedMercatorSW.y,
+  )
+  const center = mercatorToLatLng(mercatorCenter.x, mercatorCenter.y)
+
+  // New implementation
+  const newFallback = {
+    view: {
+      bounds: {
+        ne: { lat: adjustedNE.lat, lng: adjustedNE.lng },
+        sw: { lat: adjustedSW.lat, lng: adjustedSW.lng },
+      },
+      center: { lat: center.lat, lng: center.lng },
+      zoom: getZoom(
+        adjustedNE.lat,
+        adjustedNE.lng,
+        adjustedSW.lat,
+        adjustedSW.lng,
+        lastMapView.height,
+        lastMapView.width,
+      ),
+    },
+  }
+
+  const proposedZoom = getZoom(ne, sw, lastMapView.height, lastMapView.width)
+  const proposedCenter = {
+    lat: (ne.lat() + sw.lat()) / 2,
+    lng: (ne.lng() + sw.lng()) / 2,
+  }
+
+  const proposedBounds = getProposedBounds(
+    proposedCenter,
+    proposedZoom,
+    lastMapView.width,
+    lastMapView.height,
+  )
+
+  const oldFallback = {
+    view: {
+      zoom: proposedZoom,
+      center: proposedCenter,
+      bounds: proposedBounds,
+      width: lastMapView.width,
+      height: lastMapView.height,
+    },
+  }
+
+  return {
+    location: {
+      lat: location.lat(),
+      lng: location.lng(),
+      description,
+    },
+    viewport: {
+      ne: { lat: ne.lat(), lng: ne.lng() },
+      sw: { lat: sw.lat(), lng: sw.lng() },
+    },
+    ...oldFallback,
+    newFallback,
+    oldFallback,
+  }
+}
+
+const latLngToMercator = (lat, lng) => {
+  const x = (lng * EARTH_RADIUS * Math.PI) / 180
+  let y = Math.log(Math.tan(((90 + lat) * Math.PI) / 360)) * EARTH_RADIUS
+  y = Math.max(
+    -MAX_LATITUDE * EARTH_RADIUS,
+    Math.min(y, MAX_LATITUDE * EARTH_RADIUS),
+  )
+  return { x, y }
+}
+
+const mercatorToLatLng = (x, y) => {
+  const lng = (x * 180) / (EARTH_RADIUS * Math.PI)
+  const lat =
+    ((2 * Math.atan(Math.exp(y / EARTH_RADIUS)) - Math.PI / 2) * 180) / Math.PI
+  return { lat, lng }
 }

--- a/src/utils/viewportBounds.js
+++ b/src/utils/viewportBounds.js
@@ -20,7 +20,7 @@ export const getZoomedInView = (locationLat, locationLng, lastMapView) => {
   }
 }
 
-const WORLD_DIM = { height: 256, width: 256 } // tile size
+const TILE_SIZE = 256
 const ZOOM_MAX = 21 // max zoom level in Google Maps
 
 const latRad = (lat) => {
@@ -48,10 +48,10 @@ const getZoom = (north, east, south, west, height, width) => {
   }
 
   const latZoom = Math.floor(
-    Math.log(height / WORLD_DIM.height / latFraction) / Math.LN2,
+    Math.log(height / TILE_SIZE / latFraction) / Math.LN2,
   )
   const lngZoom = Math.floor(
-    Math.log(width / WORLD_DIM.width / lngFraction) / Math.LN2,
+    Math.log(width / TILE_SIZE / lngFraction) / Math.LN2,
   )
 
   return Math.min(Math.max(1, Math.min(latZoom, lngZoom)), ZOOM_MAX)
@@ -149,7 +149,6 @@ const getBoundsForScreenSize = (center, zoom, width, height) => {
 }
 
 const project = ({ lat, lng }) => {
-  const TILE_SIZE = 256
   const siny = Math.sin((lat * Math.PI) / 180)
   const x = TILE_SIZE * (0.5 + lng / 360)
   const y =
@@ -158,7 +157,6 @@ const project = ({ lat, lng }) => {
 }
 
 const unproject = ({ x, y }) => {
-  const TILE_SIZE = 256
   const lng = (x / TILE_SIZE - 0.5) * 360
   const latRadians = Math.atan(Math.sinh(Math.PI * (1 - (2 * y) / TILE_SIZE)))
   const lat = latRadians * (180 / Math.PI)

--- a/src/utils/viewportBounds.js
+++ b/src/utils/viewportBounds.js
@@ -1,22 +1,24 @@
 import { getGeocode } from 'use-places-autocomplete'
 
-const BOUND_DELTA = 0.001
+export const getZoomedInView = (locationLat, locationLng, lastMapView) => {
+  const center = { lat: locationLat, lng: locationLng }
+  const zoom = 17
+  const bounds = getBoundsForScreenSize(
+    center,
+    zoom,
+    lastMapView.width,
+    lastMapView.height,
+  )
 
-export const getZoomedInView = (locationLat, locationLng) =>
-  // Use fixed zoom level locationed at lat and long
-  ({
+  return {
     location: {
       lat: locationLat,
       lng: locationLng,
       description: `${locationLat}, ${locationLng}`,
     },
-    viewport: {
-      south: locationLat - BOUND_DELTA,
-      west: locationLng - BOUND_DELTA,
-      north: locationLat + BOUND_DELTA,
-      east: locationLng + BOUND_DELTA,
-    },
-  })
+    view: { bounds, center, zoom },
+  }
+}
 
 const WORLD_DIM = { height: 256, width: 256 } // tile size
 const ZOOM_MAX = 21 // max zoom level in Google Maps


### PR DESCRIPTION
Closes #389 .


Center is in Mercator space, thanks to Ethan for explaining how to get it in https://github.com/falling-fruit/falling-fruit-web/issues/389#issuecomment-2406801451 .

getZoom and getBoundsForScreenSize are AI generated and appear to work. I don't quite understand especially the project/unproject helper functions and their relation to latLngToMercator/mercatorToLatLng .

I could check that the centre works by logging the bounds used, as well as google's getBounds() in  src/redux/mapSlice.js .

To check center, I compared the calculated center to fitBounds + getCenter.

For zoom, I just checked a few examples at a few different scales and it matched - I originally had the zoom wrong and I've dismantled the testing jig that logged values for me. Can't be too far off!

As a bonus I've found a bug in the API when testing something - https://github.com/falling-fruit/falling-fruit-api/issues/43 - but then I've realised I used the wrong code for calculating bounds (the implementation with padding around the viewport did not seem to correctly work, but getting the bounds for zoom + center + width + height seems to be reliable).