### PR TITLE
Contain the overscroll for drawer

### DIFF
--- a/src/components/connect/ConnectLocation.js
+++ b/src/components/connect/ConnectLocation.js
@@ -104,6 +104,16 @@ const ConnectLocation = ({
     setHasCentered(false)
   }, [locationId])
 
+  useEffect(() => {
+    // If in a location drawer, contain the overscroll
+    if (!isDesktop && !isBeingEdited) {
+      document.body.style.overscrollBehaviorY = 'contain'
+      return () => {
+        document.body.style.overscrollBehaviorY = ''
+      }
+    }
+  }, [isDesktop, isBeingEdited])
+
   return null
 }
 

--- a/src/components/connect/ConnectLocation.js
+++ b/src/components/connect/ConnectLocation.js
@@ -104,16 +104,6 @@ const ConnectLocation = ({
     setHasCentered(false)
   }, [locationId])
 
-  useEffect(() => {
-    // If in a location drawer, contain the overscroll
-    if (!isDesktop && !isBeingEdited) {
-      document.body.style.overscrollBehaviorY = 'contain'
-      return () => {
-        document.body.style.overscrollBehaviorY = ''
-      }
-    }
-  }, [isDesktop, isBeingEdited])
-
   return null
 }
 

--- a/src/components/connect/ConnectOverscroll.js
+++ b/src/components/connect/ConnectOverscroll.js
@@ -1,0 +1,20 @@
+import { useEffect } from 'react'
+
+import { useIsDesktop } from '../../utils/useBreakpoint'
+
+const ConnectOverscroll = () => {
+  const isDesktop = useIsDesktop()
+
+  useEffect(() => {
+    if (!isDesktop) {
+      document.body.style.overscrollBehaviorY = 'contain'
+      return () => {
+        document.body.style.overscrollBehaviorY = ''
+      }
+    }
+  }, [isDesktop])
+
+  return null
+}
+
+export default ConnectOverscroll

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -69,6 +69,7 @@ const connectRoutes = [
    * - keep track of whether user wants street view
    * - on mobile, we need to center the map on the edited location because the UX involves panning the map on central pin
    * - on mobile, we need to disable the drawer when arriving from list view
+   * - on mobile, the drawer needs the user scrolling up and down
    *
    * actions:
    * - fetch data from backend
@@ -77,6 +78,7 @@ const connectRoutes = [
    * - sync property of being viewed in street view from URL routes to Redux
    * - on mobile, center and zoom on edited location
    * - on mobile, keep track of whether we arrived via list-locations URL
+   * - on mobile, disable default overscroll (e.g. a refresh on scroll down in Chrome)
    */
   <Route
     key="connect-location"

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -154,6 +154,7 @@ const connectRoutes = [
     {({ match }) =>
       match &&
       (!match.params.nextNextSegment ||
+        match.params.nextSegment === 'panorama' ||
         match.params.nextNextSegment === 'position') && <ConnectOverscroll />
     }
   </Route>,

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -4,6 +4,7 @@ import ConnectList from './ConnectList'
 import ConnectLocation from './ConnectLocation'
 import ConnectMap from './ConnectMap'
 import ConnectNewLocation from './ConnectNewLocation'
+import ConnectOverscroll from './ConnectOverscroll'
 import ConnectPath from './ConnectPath'
 import ConnectReview from './ConnectReview'
 import ConnectTypes from './ConnectTypes'
@@ -132,6 +133,29 @@ const connectRoutes = [
    */
   <Route key="disconnect-location" path={['/map']}>
     {({ match }) => match && <DisconnectLocation />}
+  </Route>,
+  /*
+   * ConnectOverscroll
+   * why: when we ask the user to pan on mobile or scroll a lot, sometimes they accidentally overscroll
+   *
+   * action: set a style property disabling the default 'refresh page on vertical overscroll' for list, location drawer, and pages with map on it
+   */
+  <Route
+    key="connect-overscroll"
+    path={[
+      '/locations/:locationId/:nextSegment/:nextNextSegment',
+      '/locations/:locationId/:nextSegment',
+      '/locations/:locationId',
+      '/list-locations/:locationId',
+      '/map',
+      '/list',
+    ]}
+  >
+    {({ match }) =>
+      match &&
+      (!match.params.nextNextSegment ||
+        match.params.nextNextSegment === 'position') && <ConnectOverscroll />
+    }
   </Route>,
 ]
 


### PR DESCRIPTION
Closes #516. Thanks Ethan for QA, I didn't even know this was a thing.

We set this property:
https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-y

but only vertically and only in the location drawer.