### PR TITLE
Validate form after adding a new type

### DIFF
--- a/src/components/form/ReviewForm.js
+++ b/src/components/form/ReviewForm.js
@@ -54,11 +54,7 @@ export const ReviewStep = ({ standalone, hasHeading = true }) => (
       label="Comments"
     />
 
-    <DateInput
-      name="review.observed_on"
-      label="Observed on"
-      invalidWhenUntouched
-    />
+    <DateInput name="review.observed_on" label="Observed on" />
 
     <Select
       label="Fruiting status"

--- a/src/components/form/TypesSelect.js
+++ b/src/components/form/TypesSelect.js
@@ -10,7 +10,7 @@ import { CreatableSelect } from './FormikWrappers'
 
 const TypesSelect = () => {
   const { typesAccess } = useSelector((state) => state.type)
-  const { values, setFieldValue } = useFormikContext()
+  const { values, validateForm, setFieldValue } = useFormikContext()
   const dispatch = useDispatch()
 
   const typeOptions = useMemo(() => typesAccess.asMenuEntries(), [typesAccess])
@@ -23,8 +23,9 @@ const TypesSelect = () => {
         'value',
       )
       setFieldValue('types', updatedTypes)
+      validateForm()
     },
-    [values.types, setFieldValue],
+    [values.types, setFieldValue, validateForm],
   )
 
   const handleCreateOption = useCallback(

--- a/src/components/form/TypesSelect.js
+++ b/src/components/form/TypesSelect.js
@@ -57,7 +57,6 @@ const TypesSelect = () => {
         }
         isVirtualized
         required
-        invalidWhenUntouched
         onCreateOption={handleCreateOption}
         formatCreateLabel={(inputValue) => inputValue}
       />


### PR DESCRIPTION
Closes #553.

Formik can re-validate a field after setFieldValue, but doesn't do that for the whole form, and we have just a global validator (validateLocationStep). Trigger it after adding a new type so the form realises the types field is no longer empty.