### PR TITLE
Autofix: 'On the map' checkbox causes a needless location query

### DIFF
--- a/src/components/filter/Filter.js
+++ b/src/components/filter/Filter.js
@@ -5,6 +5,7 @@ import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
 
 import { filtersChanged, selectionChanged } from '../../redux/viewChange'
+import { setShowOnlyOnMap } from '../../redux/filterSlice'
 import Input from '../ui/Input'
 import { CheckboxFilters } from './CheckboxFilters'
 import FilterButtons from './FilterButtons'
@@ -74,7 +75,7 @@ const Filter = () => {
               },
             ]}
             onChange={(values) => {
-              dispatch(filtersChanged(values))
+              dispatch(setShowOnlyOnMap(values.showOnlyOnMap))
             }}
             style={{ display: 'inline-block', marginRight: '5px' }}
           />

--- a/src/redux/filterSlice.js
+++ b/src/redux/filterSlice.js
@@ -56,6 +56,9 @@ export const filterSlice = createSlice({
     closeFilter: (state) => {
       state.isOpenInMobileLayout = false
     },
+    setShowOnlyOnMap: (state, action) => {
+      state.showOnlyOnMap = action.payload
+    },
   },
   extraReducers: {
     [fetchFilterCounts.pending]: (state) => {
@@ -87,6 +90,6 @@ export const filterSlice = createSlice({
   },
 })
 
-export const { openFilter, closeFilter } = filterSlice.actions
+export const { openFilter, closeFilter, setShowOnlyOnMap } = filterSlice.actions
 
 export default filterSlice.reducer


### PR DESCRIPTION
I've identified the issue and made the necessary changes to prevent the 'On the map' checkbox from reloading the map. The problem was in the Filter component where the 'showOnlyOnMap' checkbox was triggering a filter change that caused the map to reload. I've modified the Filter component to handle the 'showOnlyOnMap' checkbox separately from other filters that require map reloading.

Here's a summary of the changes:

1. In the Filter component, I separated the 'showOnlyOnMap' checkbox from other filters.
2. I created a new action 'setShowOnlyOnMap' in the filterSlice to handle the 'showOnlyOnMap' checkbox state change without triggering a map reload.
3. I updated the Filter component to dispatch the new 'setShowOnlyOnMap' action when the checkbox is toggled.
4. I modified the filterSlice to handle the new action and update the state accordingly.

These changes ensure that toggling the 'On the map' checkbox doesn't trigger a map reload while still updating the filter state. 
> [!CAUTION]  
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission