### PR TITLE
Better UX when forms fail

### DIFF
--- a/src/components/connect/ConnectNewLocation.js
+++ b/src/components/connect/ConnectNewLocation.js
@@ -1,7 +1,6 @@
 import { useEffect } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
-import { toast } from 'react-toastify'
 
 import { initNewLocation } from '../../redux/locationSlice'
 import { setInitialView } from '../../redux/mapSlice'
@@ -30,7 +29,7 @@ const ConnectNewLocation = () => {
       }
       dispatch(initNewLocation(view.center))
     } else {
-      toast.error(`Could not initialize new location at: ${location.pathname}`)
+      // Should only happen for an artificially constructed URL
       history.push('/map')
     }
   }, [dispatch, location.pathname]) //eslint-disable-line

--- a/src/components/form/AddTypeModal.js
+++ b/src/components/form/AddTypeModal.js
@@ -165,9 +165,11 @@ const AddTypeModal = ({ initialName, onTypeAdded }) => {
         language: i18n.language,
       }),
     ).then((action) => {
-      onTypeAdded(action.payload.newMenuEntry)
+      if (action.payload) {
+        onTypeAdded(action.payload.newMenuEntry)
+      }
+      setSubmitting(false)
     })
-    setSubmitting(false)
   }
 
   if (!isAddTypeModalOpen) {

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -9,7 +9,11 @@ import {
   MONTH_OPTIONS,
   PROPERTY_ACCESS_OPTIONS,
 } from '../../constants/form'
-import { saveFormValues, submitLocation } from '../../redux/locationSlice'
+import {
+  addNewLocation,
+  editExistingLocation,
+  saveFormValues,
+} from '../../redux/locationSlice'
 import { pathWithCurrentView } from '../../utils/appUrl'
 import {
   formToLocation,
@@ -180,11 +184,10 @@ export const LocationForm = ({ editingId, initialValues, stepped }) => {
         ]),
   ]
 
-  const handleSubmit = ({
-    'g-recaptcha-response': recaptcha,
-    review,
-    ...location
-  }) => {
+  const handleSubmit = (
+    { 'g-recaptcha-response': recaptcha, review, ...location },
+    formikProps,
+  ) => {
     const locationValues = {
       'g-recaptcha-response': recaptcha,
       lat: position?.lat,
@@ -196,11 +199,25 @@ export const LocationForm = ({ editingId, initialValues, stepped }) => {
       locationValues.review = formToReview(review)
     }
 
-    dispatch(submitLocation({ editingId, locationValues })).then((action) => {
-      if (action.payload) {
-        history.push(`/locations/${action.payload.id}`)
-      }
-    })
+    if (editingId) {
+      dispatch(editExistingLocation(editingId, locationValues)).then(
+        (action) => {
+          if (action.error) {
+            formikProps.setSubmitting(false)
+          } else {
+            history.push(`/locations/${action.payload.id}`)
+          }
+        },
+      )
+    } else {
+      dispatch(addNewLocation(locationValues)).then((action) => {
+        if (action.error) {
+          formikProps.setSubmitting(false)
+        } else {
+          history.push(`/locations/${action.payload.id}`)
+        }
+      })
+    }
   }
   const handleCancel = (e) => {
     e.stopPropagation()

--- a/src/components/form/ReportModal.js
+++ b/src/components/form/ReportModal.js
@@ -30,8 +30,7 @@ const ReportModal = ({ locationId, name, onDismiss, ...props }) => {
       response = await addReport(reportValues)
       toast.success('Report submitted successfully!')
     } catch (e) {
-      toast.error('Report submission failed.')
-      console.error(e.response)
+      toast.error(`Report submission failed: ${e.message}`)
     }
 
     if (response && !response.error) {

--- a/src/components/photo/PhotoUploader.js
+++ b/src/components/photo/PhotoUploader.js
@@ -35,9 +35,8 @@ export const PhotoUploader = ({ value, onChange }) => {
 
           try {
             resp = await addPhoto(photo.file)
-          } catch (e) {
-            toast.error(`Photo upload failed: ${e.response?.data?.error}`)
-            console.error(e)
+          } catch (error) {
+            toast.error(`Photo upload failed: ${error.message}`)
           }
 
           if (resp) {

--- a/src/redux/geolocationSlice.js
+++ b/src/redux/geolocationSlice.js
@@ -53,9 +53,7 @@ export const geolocationSlice = createSlice({
         // The last value is code 3, timeout, is unreachable as we use the default of no timeout
         // @see src/components/map/ConnectedGeolocation.js
         state.geolocationState = GeolocationState.INITIAL
-        toast.error(
-          `Geolocation failed: ${action.payload.message}. Please refresh the page and retry`,
-        )
+        toast.error(`Geolocation failed: ${action.payload.message}`)
       }
     },
   },

--- a/src/redux/mapSlice.js
+++ b/src/redux/mapSlice.js
@@ -4,7 +4,7 @@ import { eqBy, prop, unionWith } from 'ramda'
 import { getClusters, getLocations } from '../utils/api'
 import { currentPathWithView } from '../utils/appUrl'
 import { geolocationReceived, GeolocationState } from './geolocationSlice'
-import { submitLocation } from './locationSlice'
+import { addNewLocation, editExistingLocation } from './locationSlice'
 import { selectPlace } from './placeSlice'
 import { selectParams } from './selectParams'
 import { updateSelection } from './updateSelection'
@@ -86,7 +86,7 @@ export const mapSlice = createSlice({
     [fetchMapLocations.pending]: (state) => {
       state.isLoading = true
     },
-    [submitLocation.fulfilled]: (state, action) => {
+    [editExistingLocation.fulfilled]: (state, action) => {
       if (state.clusters.length) {
         return
       }
@@ -94,12 +94,14 @@ export const mapSlice = createSlice({
         (loc) => loc.id === action.payload.id,
       )
       if (index !== -1) {
-        // Update existing location
         state.locations[index] = action.payload
-      } else {
-        // Add new location
-        state.locations.push(action.payload)
       }
+    },
+    [addNewLocation.fulfilled]: (state, action) => {
+      if (state.clusters.length) {
+        return
+      }
+      state.locations.push(action.payload)
     },
     [fetchMapLocations.fulfilled]: (state, action) => {
       if (!state.googleMap) {

--- a/src/redux/typeSlice.js
+++ b/src/redux/typeSlice.js
@@ -56,8 +56,8 @@ const typeSlice = createSlice({
       toast.success('New type added successfully!')
       state.isAddTypeModalOpen = false
     },
-    [addTypeAndUpdate.rejected]: () => {
-      toast.error('Failed to add new type. Please try again.')
+    [addTypeAndUpdate.rejected]: (_state, action) => {
+      toast.error(`Adding new type failed: ${action.error.message}`)
     },
   },
 })

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -44,11 +44,11 @@ instance.interceptors.request.use((config) => {
 })
 
 instance.interceptors.response.use(
-  (response) => response.data,
+  (response) => response?.data,
   async (error) => {
     const originalRequest = error.config
-
     if (
+      error.response &&
       error.response.status === 401 &&
       error.response.data.error === 'Expired access token' &&
       !originalRequest._retry


### PR DESCRIPTION
- show errors
- set submitting to false but don't lose form state

Closes #562 

I chose this verbiage for error messages:
```
wbazant@wbazant-19-01:~/dev/falling-fruit-web$ ag 'failed: ' | grep toast
src/components/form/ReportModal.js:33:      toast.error(`Report submission failed: ${e.message}`)
src/components/photo/PhotoUploader.js:39:            toast.error(`Photo upload failed: ${error.message}`)
src/redux/typeSlice.js:60:      toast.error(`Adding new type failed: ${action.error.message}`)
src/redux/locationSlice.js:213:      toast.error(`Location submission failed: ${action.error.message}`)
src/redux/locationSlice.js:225:      toast.error(`Location editing failed: ${action.error.message}`)
src/redux/locationSlice.js:232:      toast.error(`Review submission failed: ${action.error.message}`)
src/redux/locationSlice.js:244:      toast.error(`Review editing failed: ${action.error.message}`)
src/redux/locationSlice.js:253:      toast.error(`Review deletion failed: ${action.error.message}`)
```