### PR TITLE
feat(uploadImage):  Changed upload text by icon

### DIFF
--- a/src/components/photo/PhotoOrganizer.js
+++ b/src/components/photo/PhotoOrganizer.js
@@ -1,9 +1,12 @@
-import { CloudUpload } from '@styled-icons/boxicons-regular'
-import { CloudUpload as CloudUploadSolid } from '@styled-icons/boxicons-solid'
 import { useRef } from 'react'
 import { useDropzone } from 'react-dropzone'
 import styled from 'styled-components/macro'
 
+import {
+  IconUploadSolidStyled,
+  IconUploadStyled,
+  UploadIcon,
+} from '../ui/UploadIcon'
 import { PhotoList } from './PhotoList'
 
 const StyledDropzone = styled.div`
@@ -49,15 +52,9 @@ export const PhotoOrganizer = ({ photos, onChange }) => {
     <>
       <StyledDropzone {...getRootProps()}>
         <input {...getInputProps()} />
-        {isDragActive ? (
-          <CloudUploadSolid
-            style={{ width: '45px', height: '45px', color: '#333333' }}
-          />
-        ) : (
-          <CloudUpload
-            style={{ width: '45px', height: '45px', color: '#ffa41b' }}
-          />
-        )}
+        <UploadIcon isDragActive={isDragActive}>
+          {isDragActive ? <IconUploadSolidStyled /> : <IconUploadStyled />}
+        </UploadIcon>
       </StyledDropzone>
       <PhotoList photos={photos} onChange={onChange} />
     </>

--- a/src/components/photo/PhotoOrganizer.js
+++ b/src/components/photo/PhotoOrganizer.js
@@ -1,3 +1,5 @@
+import { CloudUpload } from '@styled-icons/boxicons-regular'
+import { CloudUpload as CloudUploadSolid } from '@styled-icons/boxicons-solid'
 import { useRef } from 'react'
 import { useDropzone } from 'react-dropzone'
 import styled from 'styled-components/macro'
@@ -47,7 +49,15 @@ export const PhotoOrganizer = ({ photos, onChange }) => {
     <>
       <StyledDropzone {...getRootProps()}>
         <input {...getInputProps()} />
-        {isDragActive ? 'Drop files here' : 'Drag files or click to upload'}
+        {isDragActive ? (
+          <CloudUploadSolid
+            style={{ width: '45px', height: '45px', color: '#333333' }}
+          />
+        ) : (
+          <CloudUpload
+            style={{ width: '45px', height: '45px', color: '#ffa41b' }}
+          />
+        )}
       </StyledDropzone>
       <PhotoList photos={photos} onChange={onChange} />
     </>

--- a/src/components/ui/UploadIcon.js
+++ b/src/components/ui/UploadIcon.js
@@ -1,0 +1,24 @@
+import { CloudUpload } from '@styled-icons/boxicons-regular'
+import { CloudUpload as CloudUploadSolid } from '@styled-icons/boxicons-solid'
+import styled from 'styled-components/macro'
+
+const UploadIcon = styled.div`
+  width: 45px;
+  height: 45px;
+  color: ${({ isDragActive, theme }) =>
+    isDragActive ? theme.headerText : theme.orange};
+  margin: 0 auto;
+  transition: color 0.3s ease;
+`
+
+const IconUploadStyled = styled(CloudUpload)`
+  width: 100%;
+  height: 100%;
+`
+
+const IconUploadSolidStyled = styled(CloudUploadSolid)`
+  width: 100%;
+  height: 100%;
+`
+
+export { IconUploadSolidStyled, IconUploadStyled, UploadIcon }


### PR DESCRIPTION
This improvement replaces the 'Upload Image' text with an upload image icon. By default, the icon is orange, and when dragging files, it changes to a solid black.

Closes  #566 