### PR TITLE
Interpunct between type names

### DIFF
--- a/src/components/list/Locations.js
+++ b/src/components/list/Locations.js
@@ -10,9 +10,14 @@ import { ReactComponent as LeafIcon } from './leaf.svg'
 
 const TypeNameTagWrapper = styled.span`
   display: inline-block;
-  margin-right: 1em;
   margin-bottom: 0.5em;
   opacity: ${({ isSelected }) => (isSelected ? 1 : 0.5)};
+  font-size: 0.875rem;
+  &:not(:nth-last-child(2))::after {
+    content: '·';
+    margin: 0 0.5em;
+    color: ${({ theme }) => theme.secondaryText};
+  }
 `
 const CommonName = styled.span`
   font-weight: bold;
@@ -25,16 +30,12 @@ const ScientificName = styled.span`
   color: ${({ theme }) => theme.secondaryText};
 `
 
-const TypeNameWrapper = styled.div`
-  font-size: 0.875rem;
-`
-
 const TypeName = ({ commonName, scientificName }) => (
-  <TypeNameWrapper>
+  <span>
     {commonName && <CommonName>{commonName}</CommonName>}
     {commonName && scientificName && <span style={{ margin: '0 0.25em' }} />}
     {scientificName && <ScientificName>{scientificName}</ScientificName>}
-  </TypeNameWrapper>
+  </span>
 )
 
 const LocationItem = styled.li`


### PR DESCRIPTION
Closes #584 . Thanks @ezwelty for suggesting, I think it helps make the items visually distinct from one another, and it's just the right amount of ornament:

![Screenshot from 2024-11-11 11-01-02](https://github.com/user-attachments/assets/69babb8f-8adf-4bc4-87b6-fcde5f01425d)
![Screenshot from 2024-11-11 11-02-14](https://github.com/user-attachments/assets/d9e4e4e5-04d6-4b34-8ab1-257283036267)
![Screenshot from 2024-11-11 11-04-21](https://github.com/user-attachments/assets/0f19cc16-3c10-4e53-954c-6e0b3936ebaa)
