### PR TITLE
Fix add location position

### DIFF
--- a/src/components/connect/ConnectInitLocation.js
+++ b/src/components/connect/ConnectInitLocation.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { setIsBeingInitializedMobile } from '../../redux/locationSlice'
+import { useAppHistory } from '../../utils/useAppHistory'
+import { useIsDesktop } from '../../utils/useBreakpoint'
+
+const ConnectInitLocation = () => {
+  const isDesktop = useIsDesktop()
+  const history = useAppHistory()
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    if (isDesktop) {
+      history.push('/locations/new')
+      return
+    }
+
+    dispatch(setIsBeingInitializedMobile(true))
+    return () => {
+      dispatch(setIsBeingInitializedMobile(false))
+    }
+  }, [history, isDesktop, dispatch])
+
+  return null
+}
+
+export default ConnectInitLocation

--- a/src/components/connect/ConnectInitLocation.js
+++ b/src/components/connect/ConnectInitLocation.js
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useDispatch } from 'react-redux'
+import { useLocation } from 'react-router-dom'
 
 import { setIsBeingInitializedMobile } from '../../redux/locationSlice'
 import { useAppHistory } from '../../utils/useAppHistory'
@@ -9,18 +10,19 @@ const ConnectInitLocation = () => {
   const isDesktop = useIsDesktop()
   const history = useAppHistory()
   const dispatch = useDispatch()
+  const location = useLocation()
+  const isSettingsPage = location.pathname.startsWith('/settings')
 
   useEffect(() => {
-    if (isDesktop) {
-      history.push('/locations/new')
-      return
-    }
+    if (!isSettingsPage) {
+      if (isDesktop) {
+        history.push('/locations/new')
+        return
+      }
 
-    dispatch(setIsBeingInitializedMobile(true))
-    return () => {
-      dispatch(setIsBeingInitializedMobile(false))
+      dispatch(setIsBeingInitializedMobile(true))
     }
-  }, [history, isDesktop, dispatch])
+  }, [history, isDesktop, dispatch, isSettingsPage])
 
   return null
 }

--- a/src/components/connect/ConnectMap.js
+++ b/src/components/connect/ConnectMap.js
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux'
 
 import { setInitialView } from '../../redux/mapSlice'
 import { parseCurrentUrl } from '../../utils/appUrl'
-import ConnectPath from './ConnectPath'
 
 const DEFAULT_LAT = 40.1125785
 const DEFAULT_LNG = -88.2287926
@@ -25,7 +24,7 @@ const ConnectMap = () => {
     }
   }, [dispatch, hasInitialView]) //eslint-disable-line
 
-  return <ConnectPath />
+  return null
 }
 
 export default ConnectMap

--- a/src/components/connect/DisconnectInitLocation.js
+++ b/src/components/connect/DisconnectInitLocation.js
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useDispatch } from 'react-redux'
+
+import { setIsBeingInitializedMobile } from '../../redux/locationSlice'
+
+const DisconnectInitLocation = () => {
+  const dispatch = useDispatch()
+
+  useEffect(() => {
+    dispatch(setIsBeingInitializedMobile(false))
+  }, [dispatch])
+
+  return null
+}
+
+export default DisconnectInitLocation

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -1,5 +1,6 @@
 import { Route } from 'react-router-dom'
 
+import ConnectInitLocation from './ConnectInitLocation'
 import ConnectList from './ConnectList'
 import ConnectLocation from './ConnectLocation'
 import ConnectMap from './ConnectMap'
@@ -35,7 +36,7 @@ const connectRoutes = [
    * - get the view from URL or default to our chosen location centred on U of Illinois
    * - if this is the first render, dispatch a Redux update
    */
-  <Route key="connect-view" path={['/map', '/settings']}>
+  <Route key="connect-view" path={['/map', '/settings', '/locations/init']}>
     <ConnectMap />
   </Route>,
   /*
@@ -62,6 +63,20 @@ const connectRoutes = [
    */
   <Route key="connect-new-location" path="/locations/new">
     <ConnectNewLocation />
+  </Route>,
+  /*
+   * ConnectInitLocation
+   * why:
+   * - mobile only URL
+   * - map needs to know we're in this state rather than generic map state
+   *
+   *
+   * actions:
+   * - if on desktop because of screen resize, go to /locations/new
+   * - set a flag in redux
+   */
+  <Route key="connect-init-location" path="/locations/init">
+    <ConnectInitLocation />
   </Route>,
   /*
    * ConnectLocation
@@ -95,7 +110,8 @@ const connectRoutes = [
   >
     {({ match }) =>
       match &&
-      match.params.locationId !== 'new' && (
+      match.params.locationId !== 'new' &&
+      match.params.locationId !== 'init' && (
         <ConnectLocation
           locationId={match.params.locationId}
           isBeingEdited={match.params.nextSegment === 'edit'}
@@ -137,7 +153,7 @@ const connectRoutes = [
    *
    * action: clear location in Redux
    */
-  <Route key="disconnect-location" path={['/map']}>
+  <Route key="disconnect-location" path={['/map', '/locations/init']}>
     {({ match }) => match && <DisconnectLocation />}
   </Route>,
   /*

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -9,6 +9,7 @@ import ConnectOverscroll from './ConnectOverscroll'
 import ConnectPath from './ConnectPath'
 import ConnectReview from './ConnectReview'
 import ConnectTypes from './ConnectTypes'
+import DisconnectInitLocation from './DisconnectInitLocation'
 import DisconnectLocation from './DisconnectLocation'
 import DisconnectReview from './DisconnectReview'
 
@@ -75,7 +76,7 @@ const connectRoutes = [
    * - if on desktop because of screen resize, go to /locations/new
    * - set a flag in redux
    */
-  <Route key="connect-init-location" path="/locations/init">
+  <Route key="connect-init-location" path={['/locations/init', '/settings']}>
     <ConnectInitLocation />
   </Route>,
   /*
@@ -189,6 +190,16 @@ const connectRoutes = [
    */
   <Route key="disconnect-review" path={['/map', '/locations']}>
     {({ match }) => match && <DisconnectReview />}
+  </Route>,
+
+  /*
+   * DisconnectInitLocation
+   * why: need to clear the mobile initialization state when navigating to main views
+   *
+   * action: clear isBeingInitializedMobile in Redux when on /map or /list
+   */
+  <Route key="disconnect-init-location" path={['/map', '/list']}>
+    <DisconnectInitLocation />
   </Route>,
 ]
 

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -177,6 +177,7 @@ const MapPage = ({ isDesktop }) => {
     location: selectedLocation,
     isLoading: locationIsLoading,
     streetViewOpen: showStreetView,
+    isBeingInitializedMobile,
   } = useSelector((state) => state.location)
   const {
     mapType,
@@ -195,7 +196,7 @@ const MapPage = ({ isDesktop }) => {
           )
         : locations
 
-  const isAddingLocation = locationId === 'new'
+  const isAddingLocation = locationId === 'new' || isBeingInitializedMobile
   const isViewingLocation =
     locationId !== null && !isEditingLocation && !isAddingLocation
   const showLabels = settingsShowLabels || isAddingLocation || isEditingLocation
@@ -264,7 +265,7 @@ const MapPage = ({ isDesktop }) => {
 
   const handleAddLocationClick = () => {
     if (currentZoom >= VISIBLE_CLUSTER_ZOOM_LIMIT) {
-      history.push('/locations/new')
+      history.push('/locations/init')
     } else {
       toast.info(t('menu.zoom_in_to_add_location'))
     }
@@ -293,7 +294,7 @@ const MapPage = ({ isDesktop }) => {
     >
       {(mapIsLoading || locationIsLoading) && <BottomLeftLoadingIndicator />}
       {isAddingLocation && !isDesktop && <AddLocationCentralUnmovablePin />}
-      {!locationId && !isDesktop && (
+      {!isAddingLocation && !isEditingLocation && !isDesktop && (
         <AddLocationButton onClick={handleAddLocationClick} />
       )}
       {isEditingLocation && !isDesktop && <EditLocationCentralUnmovablePin />}
@@ -428,7 +429,9 @@ const MapPage = ({ isDesktop }) => {
               // confusingly it doesn't work from inside the component
               $geoService={getGoogleMaps && getGoogleMaps().Geocoder}
               onChange={setDraggedPosition}
-              onDragEnd={(newPosition) => dispatch(updatePosition(newPosition))}
+              onDragEnd={(newPosition) => {
+                dispatch(updatePosition(newPosition))
+              }}
             />
           )}
         </GoogleMapReact>

--- a/src/components/mobile/LocationNav.js
+++ b/src/components/mobile/LocationNav.js
@@ -53,13 +53,13 @@ const LocationNav = () => {
         path="/locations/:locationId/edit/position"
         component={LocationPositionNav}
       />
-      <Route path="/locations/new/details">
+      <Route path="/locations/new">
         <TopBarNav
-          onBack={() => history.push('/locations/new')}
+          onBack={() => history.push('/locations/init')}
           title="New location"
         />
       </Route>
-      <Route path="/locations/new">
+      <Route path="/locations/init">
         <TopBarNav
           left={
             <Instructions>
@@ -81,7 +81,7 @@ const LocationNav = () => {
                 raised
                 size={54}
                 color={theme.green}
-                onClick={() => history.push('/locations/new/details')}
+                onClick={() => history.push('/locations/new')}
               />
             </>
           }

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -34,9 +34,7 @@ const shouldDisplayMapPage = (pathname) => {
     strict: false,
   })
 
-  const isPlacingNewLocationMarker =
-    match?.params.locationId === 'new' &&
-    match?.params.nextSegment !== 'details'
+  const isPlacingNewLocationMarker = match?.params.locationId === 'init'
 
   const locationId =
     match?.params.locationId && parseInt(match.params.locationId)
@@ -104,12 +102,12 @@ const MobileLayout = () => {
               <EditLocationForm editingId={match.params.locationId} />
             )}
           </Route>
-          <Route path="/locations/new/details">
+          <Route path="/locations/new">
             <LocationForm />
           </Route>
           <Route path={['/map', '/locations', '/list', '/settings']}>
             <Switch>
-              <Route path="/locations/new" />
+              <Route path="/locations/init" />
               <Route path="/locations/:locationId/edit/position" />
               <Route path="/locations/:locationId">
                 {!streetView && <EntryMobile />}
@@ -135,7 +133,7 @@ const MobileLayout = () => {
             '/reviews/:reviewId/edit',
             '/locations/:locationId/review',
             '/locations/:locationId/edit/details',
-            '/locations/new/details',
+            '/locations/new',
           ]}
         />
         <Route>

--- a/src/components/mobile/Tabs.js
+++ b/src/components/mobile/Tabs.js
@@ -15,9 +15,12 @@ const Tabs = () => {
   const { t } = useTranslation()
   const { pathname } = useLocation()
   const history = useAppHistory()
-  const { locationId, isBeingEdited, streetViewOpen } = useSelector(
-    (state) => state.location,
-  )
+  const {
+    isBeingInitializedMobile,
+    locationId,
+    isBeingEdited,
+    streetViewOpen,
+  } = useSelector((state) => state.location)
   const isLoggedIn = useSelector((state) => !!state.auth.user)
 
   const tabs = [
@@ -71,10 +74,10 @@ const Tabs = () => {
   }, [pathname])
 
   const handleTabChange = (newTabIndex) => {
-    if (newTabIndex === 1 && locationId === 'new') {
+    if (newTabIndex === 1 && isBeingInitializedMobile) {
       // If switching to the Map tab and adding the location, reopen that view
       // to allow e.g. switching satellite view on
-      history.push(`/locations/new`)
+      history.push(`/locations/init`)
     } else if (newTabIndex === 1 && locationId && isBeingEdited) {
       // We could also be editing position of the location
       history.push(`/locations/${locationId}/edit/position`)

--- a/src/components/mobile/TopBarSwitch.js
+++ b/src/components/mobile/TopBarSwitch.js
@@ -13,6 +13,7 @@ const TopBarSwitch = () => (
         '/locations/:locationId/review',
         '/locations/:locationId/edit',
         '/locations/new',
+        '/locations/init',
       ]}
     >
       <TopBar>

--- a/src/redux/locationSlice.js
+++ b/src/redux/locationSlice.js
@@ -10,7 +10,6 @@ import {
   getLocationById,
 } from '../utils/api'
 import { fetchReviewData } from './reviewSlice'
-import { updateLastMapView } from './viewportSlice'
 
 export const fetchLocationData = createAsyncThunk(
   'location/fetchLocationData',
@@ -73,6 +72,7 @@ const locationSlice = createSlice({
       drawerDisabled: false,
       tabIndex: 0,
     },
+    isBeingInitializedMobile: false,
   },
   reducers: {
     clearLocation: (state) => {
@@ -155,13 +155,11 @@ const locationSlice = createSlice({
     setFromSettings: (state, action) => {
       state.fromSettings = action.payload
     },
+    setIsBeingInitializedMobile: (state, action) => {
+      state.isBeingInitializedMobile = action.payload
+    },
   },
   extraReducers: {
-    [updateLastMapView]: (state, action) => {
-      if (state.locationId === 'new') {
-        state.position = action.payload.center
-      }
-    },
     [fetchLocationData.pending]: (state, action) => {
       state.location = null
       state.locationId = parseInt(action.meta.arg.locationId)
@@ -276,6 +274,7 @@ export const {
   fullyOpenPaneDrawer,
   partiallyClosePaneDrawer,
   setFromSettings,
+  setIsBeingInitializedMobile,
 } = locationSlice.actions
 
 export default locationSlice.reducer


### PR DESCRIPTION
Closes #580 

Thanks for spotting! I broke this when changing how the map worked, I've put a bit of code in redux locationSlice, that updated position when the map was moved, but I forgot to only do it on mobile.

I could have added an "only if mobile" to the above but I thought a better solution was to change the routes for adding location: from /locations/new and /locations/new/details, to /locations/init and /locations/new. This works better - the first step of adding location is just a "map but with a marker in the middle" and the second step when the user fills in types, is the correct analogue to the desktop form + map view.