### PR TITLE
fix(#595): Fixed navbar content overflow for small devices

### DIFF
--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -51,9 +51,10 @@ const StyledHeader = styled.header`
     ul {
       list-style: none;
       padding: 0;
-      margin: 0 0 0 0;
+      margin: 0;
       height: 100%;
       display: flex;
+      align-items: center;
 
       li {
         display: flex;
@@ -66,6 +67,10 @@ const StyledHeader = styled.header`
         position: relative;
         font-weight: bold;
         font-size: 1rem;
+
+        @media (min-width: 770px) and (max-width: 820px) {
+          min-width: unset;
+        }
 
         a,
         .content button {

--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -68,7 +68,7 @@ const StyledHeader = styled.header`
         font-weight: bold;
         font-size: 1rem;
 
-        @media (min-width: 770px) and (max-width: 820px) {
+        @media (min-width: 767px) and (max-width: 820px) {
           min-width: unset;
         }
 


### PR DESCRIPTION
Fixed overflow for devices in width from 770px to 820px
Also fixed alignment for "Map" and "About" since they weren't aligned properly. There was minor difference.

TESTING RESULTS:

<img width="837" alt="Screenshot 2024-11-15 at 10 28 53 PM" src="https://github.com/user-attachments/assets/d6f69457-4a64-4288-bd75-180a11a5dc17">
<img width="852" alt="Screenshot 2024-11-15 at 10 29 33 PM" src="https://github.com/user-attachments/assets/a685f405-a8c6-4204-ba9d-ada9d8efbe0c">


Closes #595
