### PR TITLE
Try fix geolocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-select": "^4.3.0",
     "react-split-pane": "^0.1.92",
     "react-toastify": "^8.1.0",
-    "react-use": "^17.2.1",
     "react-virtualized-auto-sizer": "^1.0.6",
     "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",

--- a/src/redux/geolocationSlice.js
+++ b/src/redux/geolocationSlice.js
@@ -6,7 +6,6 @@ import { updateLastMapView } from './viewportSlice'
 
 export const GeolocationState = {
   INITIAL: 'INITIAL',
-  REQUESTED: 'REQUESTED',
   DENIED: 'DENIED',
   LOADING: 'LOADING',
   FIRST_LOCATION: 'FIRST_LOCATION',
@@ -23,7 +22,7 @@ export const geolocationSlice = createSlice({
   },
   reducers: {
     requestGeolocation: (state) => {
-      state.geolocationState = GeolocationState.REQUESTED
+      state.geolocationState = GeolocationState.LOADING
     },
     geolocationDenied: (state) => {
       state.geolocationState = GeolocationState.DENIED
@@ -31,9 +30,6 @@ export const geolocationSlice = createSlice({
     disableGeolocation: (state) => {
       state.geolocationState = GeolocationState.INITIAL
       state.geolocation = null
-    },
-    geolocationLoading: (state) => {
-      state.geolocationState = GeolocationState.LOADING
     },
     geolocationCentering: (state, action) => {
       state.geolocationState = GeolocationState.CENTERING


### PR DESCRIPTION
Closes #505 - I didn't test locally on a phone because I'd need to set up https on my laptop, but I propose we try it :).

In terms of how geolocation API is called, I'm replacing https://github.com/streamich/react-use/blob/master/src/useGeolocation.ts 
```
    navigator.geolocation.getCurrentPosition(onEvent, onEventError, options);
    watchId = navigator.geolocation.watchPosition(onEvent, onEventError, options);
```

with doing just the second call - AI generated and it seems to still work, I'm not sure why the package was doing both of these.

Also, I was able to slightly simplify the existing solution.