### PR TITLE
Fix edit location

### DIFF
--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -198,15 +198,15 @@ export const LocationForm = ({ editingId, initialValues, stepped }) => {
     }
 
     if (editingId) {
-      dispatch(editExistingLocation(editingId, locationValues)).then(
-        (action) => {
-          if (action.error) {
-            formikProps.setSubmitting(false)
-          } else {
-            history.push(`/locations/${action.payload.id}`)
-          }
-        },
-      )
+      dispatch(
+        editExistingLocation({ locationId: editingId, locationValues }),
+      ).then((action) => {
+        if (action.error) {
+          formikProps.setSubmitting(false)
+        } else {
+          history.push(`/locations/${action.payload.id}`)
+        }
+      })
     } else {
       dispatch(addNewLocation(locationValues)).then((action) => {
         if (action.error) {

--- a/src/redux/locationSlice.js
+++ b/src/redux/locationSlice.js
@@ -31,7 +31,7 @@ export const addNewLocation = createAsyncThunk(
 
 export const editExistingLocation = createAsyncThunk(
   'location/editExistingLocation',
-  editLocation,
+  ({ locationId, locationValues }) => editLocation(locationId, locationValues),
 )
 
 export const addNewReview = createAsyncThunk(


### PR DESCRIPTION
Closes #630 

Only took five minutes to fix after I had sleep! this got broken when I was rewriting that code, and forgot that createAsyncThunk output will take args for the wrapped function as a first arg, and dispatch-related args as a second arg.

This is from a console.log put in src/utils/api.ts for editLocation, before and after fix:
![Screenshot from 2024-12-06 10-50-46](https://github.com/user-attachments/assets/15073002-a9bc-41aa-9e52-391ba18a46b7)
