### PR TITLE
Bump actions/cache@v2 to v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-cache


### PR DESCRIPTION
As announced (https://github.com/actions/cache/discussions/1510), actions/cache@v2 expires on 1 February 2015.
