### PR TITLE
Improve type search

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "react-split-pane": "^0.1.92",
     "react-toastify": "^8.1.0",
     "react-virtualized-auto-sizer": "^1.0.6",
-    "react-window": "^1.8.6",
     "react-window-infinite-loader": "^1.0.7",
     "reaptcha": "^1.7.3",
     "styled-components": "^5.2.1",

--- a/src/components/form/TypesSelect.js
+++ b/src/components/form/TypesSelect.js
@@ -2,21 +2,18 @@ import { useFormikContext } from 'formik'
 import { uniqBy } from 'lodash'
 import React, { useCallback, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
-import { createFilter } from 'react-select'
 
 import { openAddTypeModal } from '../../redux/typeSlice'
-import { TOKEN_START } from '../../utils/localizedTypes'
+import { tokenizeQuery } from '../../utils/tokenize'
 import { TypeName } from '../ui/TypeName'
 import { AddTypeModal } from './AddTypeModal'
 import { CreatableSelect } from './FormikWrappers'
-
-const baseFilter = createFilter()
 
 export const matchFromTokenStart = (candidate, input) => {
   if (!input || candidate.data.__isNew__) {
     return true
   } else {
-    return baseFilter(candidate, `${TOKEN_START}${input}`)
+    return candidate.data.searchReference.indexOf(tokenizeQuery(input)) > -1
   }
 }
 

--- a/src/components/form/TypesSelect.js
+++ b/src/components/form/TypesSelect.js
@@ -2,11 +2,23 @@ import { useFormikContext } from 'formik'
 import { uniqBy } from 'lodash'
 import React, { useCallback, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
+import { createFilter } from 'react-select'
 
 import { openAddTypeModal } from '../../redux/typeSlice'
+import { TOKEN_START } from '../../utils/localizedTypes'
 import { TypeName } from '../ui/TypeName'
 import { AddTypeModal } from './AddTypeModal'
 import { CreatableSelect } from './FormikWrappers'
+
+const baseFilter = createFilter()
+
+export const matchFromTokenStart = (candidate, input) => {
+  if (!input || candidate.data.__isNew__) {
+    return true
+  } else {
+    return baseFilter(candidate, `${TOKEN_START}${input}`)
+  }
+}
 
 const TypesSelect = () => {
   const { typesAccess } = useSelector((state) => state.type)
@@ -59,6 +71,7 @@ const TypesSelect = () => {
         required
         onCreateOption={handleCreateOption}
         formatCreateLabel={(inputValue) => inputValue}
+        filterOption={matchFromTokenStart}
       />
       <AddTypeModal initialName={newTypeInput} onTypeAdded={handleNewType} />
     </>

--- a/src/components/ui/Select.js
+++ b/src/components/ui/Select.js
@@ -80,8 +80,8 @@ const SelectParent = styled.div`
 const StyledSelect = SelectParent.withComponent(Select)
 const StyledCreatableSelect = SelectParent.withComponent(Creatable)
 
-const INITIAL_VISIBLE_COUNT = 20
-const INCREMENT = 10
+const INITIAL_VISIBLE_COUNT = 100
+const INCREMENT = 100
 
 const InfiniteMenuList = ({ children }) => {
   const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE_COUNT)

--- a/src/components/ui/TypeName.js
+++ b/src/components/ui/TypeName.js
@@ -57,6 +57,6 @@ export const TypeName = ({ commonName, scientificName, synonyms }) => (
       {commonName && <CommonName>{commonName}</CommonName>}
       {scientificName && <ScientificName>{scientificName}</ScientificName>}
     </NamesBlock>
-    {synonyms?.length > 0 && <Synonyms> {synonyms.join(', ')}</Synonyms>}
+    {synonyms?.length > 0 && <Synonyms> {synonyms.join(' · ')}</Synonyms>}
   </TypeNameWrapper>
 )

--- a/src/components/ui/TypeName.js
+++ b/src/components/ui/TypeName.js
@@ -1,12 +1,21 @@
 import styled from 'styled-components/macro'
 
-const CommonName = styled.span`
+const NamesBlock = styled.span`
+  .select__control & {
+    display: flex;
+    flex-wrap: wrap;
+  }
   .select__option & {
     display: block;
   }
+`
 
+const CommonName = styled.span`
   font-weight: bold;
   color: ${({ theme }) => theme.headerText};
+  .select__control & {
+    margin-right: 0.5em;
+  }
 `
 
 const ScientificName = styled.span`
@@ -19,20 +28,35 @@ const ScientificName = styled.span`
   color: ${({ theme }) => theme.secondaryText};
 `
 
-const TypeNameWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
-  font-size: 0.875rem;
+const Synonyms = styled.span`
+  color: ${({ theme }) => theme.secondaryText};
 
+  .select__control & {
+    display: none;
+  }
   .select__option & {
     display: block;
+    flex: 1;
+    text-align: right;
   }
 `
 
-export const TypeName = ({ commonName, scientificName }) => (
+const TypeNameWrapper = styled.div`
+  font-size: 0.875rem;
+
+  .select__option & {
+    width: 100%;
+    display: flex;
+    align-items: center;
+  }
+`
+
+export const TypeName = ({ commonName, scientificName, synonyms }) => (
   <TypeNameWrapper>
-    {commonName && <CommonName>{commonName}</CommonName>}
-    {scientificName && <ScientificName>{scientificName}</ScientificName>}
+    <NamesBlock>
+      {commonName && <CommonName>{commonName}</CommonName>}
+      {scientificName && <ScientificName>{scientificName}</ScientificName>}
+    </NamesBlock>
+    {synonyms?.length > 0 && <Synonyms> {synonyms.join(', ')}</Synonyms>}
   </TypeNameWrapper>
 )

--- a/src/utils/localizedTypes.ts
+++ b/src/utils/localizedTypes.ts
@@ -19,6 +19,7 @@ export type LocalizedType = {
   taxonomicRank: number
   urls: { [url: string]: string }
   categories: string[]
+  synonyms: string[]
 }
 
 type TypeSelectMenuEntry = {
@@ -26,6 +27,7 @@ type TypeSelectMenuEntry = {
   label: string
   scientificName: string
   commonName: string
+  synonyms: string[]
   taxonomicRank: number
 }
 
@@ -38,6 +40,8 @@ const localize = (type: SchemaType, language: string): LocalizedType => {
     commonName = type.common_names?.en?.[0] || ''
   }
 
+  const synonyms = type.common_names?.[language]?.slice(1) || []
+
   return {
     id: type.id,
     parentId: type.pending ? PENDING_ID : type.parent_id || 0,
@@ -46,6 +50,7 @@ const localize = (type: SchemaType, language: string): LocalizedType => {
     taxonomicRank: type.taxonomic_rank || 0,
     urls: type.urls || {},
     categories: type.categories || [],
+    synonyms,
   }
 }
 
@@ -63,7 +68,8 @@ const createTypesAccess = (localizedTypes: LocalizedType[]) => {
 }
 
 const toMenuEntry = (localizedType: LocalizedType) => {
-  const { id, commonName, scientificName, taxonomicRank } = localizedType
+  const { id, commonName, scientificName, taxonomicRank, synonyms } =
+    localizedType
   const label =
     scientificName && commonName
       ? `${scientificName} (${commonName})`
@@ -76,6 +82,7 @@ const toMenuEntry = (localizedType: LocalizedType) => {
     commonName,
     scientificName,
     taxonomicRank,
+    synonyms,
   }
 }
 
@@ -179,6 +186,7 @@ export const typesAccessInLanguage = (
       taxonomicRank: 0,
       urls: {},
       categories: [],
+      synonyms: [],
     })
   }
   return createTypesAccess(toDisplayOrder(localizedTypes))

--- a/src/utils/localizedTypes.ts
+++ b/src/utils/localizedTypes.ts
@@ -67,18 +67,16 @@ const createTypesAccess = (localizedTypes: LocalizedType[]) => {
   return new TypesAccess(localizedTypes, idIndex, childrenById)
 }
 
+export const TOKEN_START = '^'
+
 const toMenuEntry = (localizedType: LocalizedType) => {
   const { id, commonName, scientificName, taxonomicRank, synonyms } =
     localizedType
-  const label =
-    scientificName && commonName
-      ? `${scientificName} (${commonName})`
-      : scientificName
-        ? scientificName
-        : `"${commonName}"`
   return {
     value: id,
-    label: label,
+    label: [commonName, scientificName, ...synonyms]
+      .map((x) => `${TOKEN_START}${x}`)
+      .join(''),
     commonName,
     scientificName,
     taxonomicRank,

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -1,0 +1,132 @@
+interface AsciiMap {
+  [key: string]: string
+}
+
+const ASCII: { [key: string]: string } = {
+  A: 'AⒶＡÀÁÂẦẤẪẨÃĀĂẰẮẴẲȦǠÄǞẢÅǺǍȀȂẠẬẶḀĄȺⱯ',
+  AA: 'Ꜳ',
+  AE: 'ÆǼǢ',
+  AO: 'Ꜵ',
+  AU: 'Ꜷ',
+  AV: 'ꜸꜺ',
+  AY: 'Ꜽ',
+  B: 'BⒷＢḂḄḆɃƂƁ',
+  C: 'CⒸＣĆĈĊČÇḈƇȻ',
+  D: 'DⒹＤḊĎḌḐḒḎĐƋƊƉ',
+  DZ: 'ǱǄ',
+  Dz: 'ǲǅ',
+  E: 'EⒺＥÈÉÊỀẾỄỂẼĒḔḖĔĖËẺĚȄȆẸỆȨḜĘḘḚƐƎ',
+  F: 'FⒻＦḞƑ',
+  G: 'GⒼＧǴĜḠĞĠǦĢǤƓꞠ',
+  H: 'HⒽＨĤḢḦȞḤḨḪĦⱧ',
+  I: 'IⒾＩÌÍÎĨĪĬİÏḮỈǏȈȊỊĮḬƗ',
+  J: 'JⒿＪĴ',
+  K: 'KⓀＫḰǨḲĶḴƘⱩꝀꝂꝄꞢ',
+  L: 'LⓁＬĿĹĽḶḸĻḼḺŁȽⱢⱠꝈ',
+  LJ: 'Ǉ',
+  Lj: 'ǈ',
+  M: 'MⓂＭḾṀṂƜ',
+  N: 'NⓃＮǸŃÑṄŇṆŅṊṈȠƝꞐꞤ',
+  NJ: 'Ǌ',
+  Nj: 'ǋ',
+  O: 'OⓄＯÒÓÔỒỐỖỔÕṌȬṎŌṐṒŎȮȰÖȪỎŐǑȌȎƠỜỚỠỞỢỌỘǪǬØǾƆƟꝊꝌ',
+  OE: 'Œ',
+  OI: 'Ƣ',
+  OO: 'Ꝏ',
+  OU: 'Ȣ',
+  P: 'PⓅＰṔṖƤⱣꝐꝒꝔ',
+  Q: 'QⓆＱꝖꝘ',
+  R: 'RⓇＲŔṘŘȐȒṚṜŖṞɌⱤꝚꞦ',
+  S: 'SⓈＳẞŚṤŜṠŠṦṢṨȘŞⱾꞨ',
+  T: 'TⓉＴṪŤṬȚŢṰṮŦƬƮȾ',
+  TZ: 'Ꜩ',
+  U: 'UⓊＵÙÚÛŨṸŪṺŬÜǛǗǕǙỦŮŰǓȔȖƯỪỨỮỬỰỤṲŲṶṴɄ',
+  V: 'VⓋＶṼṾƲꝞɅ',
+  VY: 'Ꝡ',
+  W: 'WⓌＷẀẂŴẆẄẈⱲ',
+  X: 'XⓍＸẊẌ',
+  Y: 'YⓎＹỲÝŶỸȲẎŸỶỴƳɎỾ',
+  Z: 'ZⓏＺŹẐŻŽẒẔƵȤⱿⱫꝢ',
+  a: 'aⓐａẚàáâầấẫẩãāăằắẵẳȧǡäǟảåǻǎȁȃạậặḁąⱥɐꜳ',
+  ae: 'æǽǣ',
+  ao: 'ꜵ',
+  au: 'ꜷ',
+  av: 'ꜹꜻ',
+  ay: 'ꜽ',
+  b: 'bⓑｂḃḅḇƀƃɓ',
+  c: 'cⓒｃćĉċčçḉƈȼ',
+  d: 'dⓓｄḋďḍḑḓḏđƌɖɗꝺð',
+  dz: 'ǳǆ',
+  e: 'eⓔｅèéêềếễểẽēḕḗĕėëẻěȅȇẹệȩḝęḙḛɇɛǝ',
+  f: 'fⓕｆḟƒ',
+  g: 'gⓖｇǵĝḡğġǧģǥɠꞡᵹ',
+  h: 'hⓗｈĥḣḧȟḥḩḫẖħⱨɥ',
+  hv: 'ƕ',
+  i: 'iⓘｉìíîĩīĭïḯỉǐȉȋịįḭɨı',
+  j: 'jⓙｊĵǰɉ',
+  k: 'kⓚｋḱǩḳķḵƙⱪꝁꝃꝅꞣ',
+  l: 'lⓛｌŀĺľḷḹļḽḻłƚɫ',
+  lj: 'ǉ',
+  m: 'mⓜｍḿṁṃɱɯᶆ',
+  n: 'nⓝｎǹńñṅňṇņṋṉƞɲŉꞑꞥ',
+  nj: 'ǌ',
+  o: 'oⓞｏòóôồốỗổõṍȭṏōṑṓŏȯȱöȫỏőǒȍȏơờớỡởợọộǫǭøǿɔꝋꝍɵ',
+  oe: 'œ',
+  oi: 'ƣ',
+  ou: 'ȣ',
+  oo: 'ꝏ',
+  p: 'pⓟｐṕṗƥᵽꝑꝓꝕ',
+  q: 'qⓠｑɋꝗꝙ',
+  r: 'rⓡｒŕṙřȑȓṛṝŗṟɍɽ',
+  s: 'sⓢｓśṥŝṡšṧṣṩșşȿꞩẛſß',
+  t: 'tⓣｔṫẗťṭțţṱṯŧƭʈⱦ',
+  tz: 'ꜩ',
+  u: 'uⓤｕùúûũṹūṻŭüǜǘǖǚủůűǔȕȗưừứữửựụṳųṷṵʉ',
+  v: 'vⓥｖṽṿʋꝟʌ',
+  w: 'wⓦｗẁẃŵẇẅẘẉⱳ',
+  x: 'xⓧẋẍxᶍｘ',
+  y: 'yⓨｙỳýŷỹȳẏÿỷẙỵƴɏỿ',
+  z: 'zⓩｚźẑżžẓẕƶȥɀⱬ',
+}
+
+const ASCII_MAP: AsciiMap = {}
+for (const key in ASCII) {
+  for (const letter of ASCII[key]) {
+    ASCII_MAP[letter] = key
+  }
+}
+
+const TOKEN_START = '^'
+const WORD_END = ' '
+
+type Transform = (_input: string) => string
+
+const pipe =
+  (...fns: Transform[]): Transform =>
+  (x) =>
+    fns.reduce((v, f) => f(v), x)
+
+const removeNonWordChars: Transform = (s) => s.replace(/[^\s\w]/g, '')
+
+const convertToAscii: Transform = (s) =>
+  s
+    .split('')
+    .map((c) => ASCII_MAP[c] || c)
+    .join('')
+
+const addTokenStart: Transform = (s) => `${TOKEN_START}${s}`
+
+const addTokenStartEnd: Transform = (s) => `${TOKEN_START}${s}${WORD_END}`
+
+const rightTrimWithWordEnd: Transform = (s) => s.replace(/\s+$/, WORD_END)
+
+const tokenize = pipe(
+  removeNonWordChars,
+  (x) => x.toLowerCase(),
+  convertToAscii,
+)
+
+export const tokenizeReference = (strings: string[]): string =>
+  strings.map(pipe(tokenize, addTokenStartEnd)).join('')
+
+export const tokenizeQuery = pipe(tokenize, addTokenStart, rightTrimWithWordEnd)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7944,7 +7944,7 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-"memoize-one@>=3.1.1 <6", memoize-one@^5.0.0, memoize-one@^5.1.1:
+memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -10291,14 +10291,6 @@ react-window-infinite-loader@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/react-window-infinite-loader/-/react-window-infinite-loader-1.0.7.tgz#958ef1a689d20dce122ef377583acd987760aee8"
   integrity sha512-wg3LWkUpG21lhv+cZvNy+p0+vtclZw+9nP2vO6T9PKT50EN1cUq37Dq6FzcM38h/c2domE0gsUhb6jHXtGogAA==
-
-react-window@^1.8.6:
-  version "1.8.6"
-  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
-  integrity sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==
-  dependencies:
-    "@babel/runtime" "^7.0.0"
-    memoize-one ">=3.1.1 <6"
 
 react@^17.0.1:
   version "17.0.2"


### PR DESCRIPTION
Closes #635 

Different resolution:
1. show the synonyms when selecting

As Ethan points out, the synonyms can help find the match, but just using them in the background would produce a "matching but not sure why" experience. Meanwhile, they're quite interesting - a bit of trivia about plants of the form: okra is also known as Ladies' fingers - and might help also when browsing.

2. don't reorder search results

I proposed that solution originally, and from searching it seems to be borderline possible, but the library really didn't want me to do it, and it probably has drawbacks. Instead, match from the start only, and use common name + scientific name + all synonyms as possible starts.

