### PR TITLE
Auto-choose on enter, blur on choose

### DIFF
--- a/src/components/search/Search.js
+++ b/src/components/search/Search.js
@@ -118,6 +118,8 @@ const Search = (props) => {
       ? data
       : []
 
+  const inputRef = useRef()
+
   useEffect(() => {
     if (googleMap) {
       init()
@@ -165,6 +167,7 @@ const Search = (props) => {
       )
       dispatch(selectPlace({ place: placeBounds }))
     }
+    inputRef.current?.blur()
   }
   const handleFocus = () => {
     setHasFocus(true)
@@ -185,6 +188,20 @@ const Search = (props) => {
           onChange={handleChange}
           onFocus={handleFocus}
           disabled={!ready}
+          ref={inputRef}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && suggestionsList.length > 0) {
+              // Expand choosing with Enter to include first suggestion
+              // (but don't clash with arrow down + enter)
+              const highlightedIndex =
+                document.querySelector('[data-highlighted]')
+              if (!highlightedIndex) {
+                e.preventDefault()
+                const firstSuggestion = suggestionsList[0]
+                handleSelect(firstSuggestion.description)
+              }
+            }
+          }}
           icon={
             value === '' ? (
               <SearchAlt2 />


### PR DESCRIPTION
Closes #240

I originally added the blur effect only after enter, because it closes the keyboard, but I think it's desirable overall: once the user selected a location, they're done with the search box.
