### PR TITLE
Restore geolocation tracking

### DIFF
--- a/src/components/map/ConnectGeolocation.js
+++ b/src/components/map/ConnectGeolocation.js
@@ -49,6 +49,7 @@ const useGeolocation = () => {
         latitude,
         longitude,
         error: null,
+        timestamp: position.timestamp,
       })
     }
 


### PR DESCRIPTION
Closes #671 

I've braced myself for a debugging nightmare because I have a constant location on desktop, but actually, adding a random jitter inside src/components/map/ConnectGeolocation.js was enough to see what's going on. Then I noticed the argument wasn't passed through, possibly an accident when editing - restoring the argument lets me observe a jittery dot on desktop, should be good on mobile as well.