### PR TITLE
Use mobile translations

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -116,12 +116,6 @@
         "the_data": "The data",
         "the_project": "The project"
       }
-    },
-    "page_title": {
-      "adding_location": "Adding Location",
-      "adding_review": "Adding Review",
-      "editing_location": "Editing Location",
-      "editing_review": "Editing Review"
     }
   },
   "locations": {
@@ -153,6 +147,10 @@
     }
   },
   "menu": {
+    "add_location": "Add location",
+    "add_review": "Add review",
+    "edit_location": "Edit location",
+    "edit_review": "Edit review",
     "zoom_in_to_add_location": "Zoom in to add location"
   },
   "metric": "Metric",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -1,211 +1,140 @@
 {
-  "language": "Language",
-  "units": "Units",
-  "metric": "Metric",
-  "imperial": "Imperial",
-  "roadmap": "Map",
-  "poi": "Points of interest",
-  "settings": "Settings",
-  "type": "Type",
-  "select_all": "Select all",
-  "deselect_all": "Deselect all",
-  "only_on_map": "On the map",
-  "required": "Required",
-  "optional": "Optional",
-  "back": "Back",
   "added_by": "Added by {{name}}",
-  "imported_from": "Imported from {{name}}",
+  "back": "Back",
+  "changes": {
+    "change_in_city": "{{type}} in {{city}}",
+    "recent_changes": "Recent changes",
+    "type": {
+      "added": "added",
+      "edited": "edited",
+      "grafted": "grafted",
+      "visited": "visited"
+    }
+  },
+  "deselect_all": "Deselect all",
+  "devise": {
+    "confirmations": {
+      "confirmed": "Your email address has been successfully confirmed.",
+      "no_token": "You can't access this page without coming from a confirmation email. If you do, please make sure you used the full URL provided.",
+      "send_instructions": "You will receive an email with instructions for how to confirm your email address in a few minutes."
+    },
+    "failure": {
+      "already_authenticated": "You are already signed in."
+    },
+    "passwords": {
+      "no_token": "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.",
+      "send_instructions": "You will receive an email with instructions on how to reset your password in a few minutes.",
+      "updated_not_active": "Your password has been changed successfully."
+    },
+    "registrations": {
+      "signed_up": "Welcome! You have signed up successfully.",
+      "update_needs_confirmation": "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address.",
+      "updated": "Your account has been updated successfully."
+    }
+  },
   "edited_on": "Edited on {{date}}",
-  "glossary": {
-    "activity": "Activity",
-    "about": "About",
-    "list": "List",
-    "address": "Address",
-    "types": "Types",
-    "data": "Data",
-    "map": "Map",
-    "labels": "Labels",
-    "login": "Login",
-    "logout": "Logout",
-    "sign_up": "Sign up",
-    "account": "Account",
-    "email": "Email",
-    "password": "Password",
-    "name": "Name",
-    "send": "Send",
-    "save_changes": "Save changes",
-    "edit": "Edit",
-    "donate": "Donate",
-    "quality": "Quality",
-    "yield": "Yield",
-    "report": "Report",
-    "position": "Position",
-    "description": "Description",
-    "unverified": "Unverified",
-    "submit": "Submit",
-    "delete": "Delete",
-    "imported_datasets": "Imported datasets",
-    "tree_inventory": {
-      "one": "Tree inventory"
-    },
-    "locations": {
-      "other": "Locations"
-    },
-    "links": {
-      "one": "Link"
-    },
-    "australia": "Australia",
-    "belgium": "Belgium",
-    "brazil": "Brazil",
-    "canada": "Canada",
-    "chile": "Chile",
-    "czechia": "Czechia",
-    "fiji": "Fiji",
-    "finland": "Finland",
-    "france": "France",
-    "germany": "Germany",
-    "greece": "Greece",
-    "ireland": "Ireland",
-    "italy": "Italy",
-    "new_zealand": "New Zealand",
-    "portugal": "Portugal",
-    "spain": "Spain",
-    "sweden": "Sweden",
-    "switzerland": "Switzerland",
-    "united_kingdom": "United Kingdom",
-    "united_states": "United States",
-    "season": "Season",
-    "access": "Access",
-    "add_source": "Add location"
-  },
-  "side_menu": {
-    "regional": "Regional",
-    "satellite": "Satellite",
-    "terrain": "Terrain",
-    "bicycle": "Biking",
-    "transit": "Transit"
-  },
-  "menu": {
-    "zoom_in_to_add_location": "Zoom in to add location"
-  },
-  "layouts": {
-    "page_title": {
-      "editing_location": "Editing Location",
-      "adding_location": "Adding Location",
-      "adding_review": "Adding Review",
-      "editing_review": "Editing Review"
-    },
-    "application": {
-      "menu": {
-        "the_project": "The project",
-        "the_data": "The data",
-        "sharing_the_harvest": "Sharing the harvest",
-        "in_the_press": "In the press"
-      }
-    }
-  },
-  "pages": {
-    "about": {
-      "ff_disclaimer_html": "Falling Fruit is not associated with Fallen Fruit. Fallen Fruit can be found at <a href=\"http://fallenfruit.org\">fallenfruit.org</a>.",
-      "give_us_money": "We are a 501(c)(3) nonprofit and rely on donations to operate. If you are willing and able, please consider making a financial contribution. Donations within the United States are tax deductible.",
-      "give_paypal": "Donate via Paypal Giving Fund",
-      "write": "Write",
-      "contact_us_html": "Falling Fruit is built by and for foragers – we want it to be the best tool available to the contemporary forager. Write us at <a href=\"mailto:feedback@fallingfruit.org\">feedback@fallingfruit.org</a>, we would love to hear from you!",
-      "translate": "Translate",
-      "translate_for_us_html": "Interested in volunteering as a translator? Email us and we'll invite you to join us on <a href=\"https://phrase.com\">Phrase</a>, where our translations are managed.",
-      "about_the_site": "About the project",
-      "celebration": "Falling Fruit is a celebration of the overlooked culinary bounty of our city streets. By quantifying this resource on an interactive map, we hope to facilitate intimate connections between people, food, and the natural organisms growing in our neighborhoods. Not just a free lunch! Foraging in the 21st century is an opportunity for urban exploration, to fight the scourge of stained sidewalks, and to reconnect with the botanical origins of food.",
-      "more_about_html": "Our edible map is not the first of its kind, but it aspires to be the world's most comprehensive. While our users contribute locations of their own, we comb the internet for pre-existing knowledge, seeking to unite the efforts of foragers, foresters, and freegans everywhere. The <a href=\"/datasets\">imported datasets</a> range from small neighborhood foraging maps to vast professionally-compiled tree inventories. This so far amounts to {{types}} different types of edibles (most, but not all, plant species) distributed over {{locations}} locations. Beyond the cultivated and commonplace to the exotic flavors of foreign plants and long-forgotten native plants, foraging in your neighborhood is a journey through time and across cultures.",
-      "join_us_html": "Join us in celebrating hyper-local food! The <a href=\"/\">map</a> is open for anyone to edit, the database can be <a href=\"/data\">downloaded</a> with just one click, and <a href=\"https://github.com/falling-fruit/\">the code</a> is open-source. You are likewise encouraged to share the bounty with your fellow humans. Our <a href=\"/sharing\">sharing page</a> lists hundreds of local organizations - planting public orchards and food forests, picking otherwise-wasted fruits and vegetables from city trees and farmers' fields, and sharing with neighbors and the needy.",
-      "staff": "Staff",
-      "ethan_welty_bio_html": "With technology and data, Ethan champions cities as sources of fresh and free food. He created Falling Fruit with Caleb Phillips in 2013 to promote urban foraging worldwide, and co-founded <a href=\"https://fruitrescue.org\">Community Fruit Rescue</a> in 2014 to harvest and distribute surplus fruit growing around him in Boulder, Colorado. Beyond fruit, he juggles a <a href=\"https://www.weltyphotography.com\">photography career</a>, <a href=\"https://instaar.colorado.edu/people/ethan-welty/\">research on glaciers</a>, and an appetite for mountainous and riverine pursuits.",
-      "directors": "Board of directors",
-      "jeff_wanner_bio_html": "Since harvesting black and blueberries with his family as a child and, more recently, noticing the wealth of public fruit trees throughout Colorado, Jeff has developed a deep appreciation for the abundance of fruit growing in our cities. His first mission for Falling Fruit was to comb Boulder and Salt Lake City, paper maps in-hand, to record fruiting trees. When not working to improve building energy efficiency, he is usually helping out in the community or moving quickly over mountains by foot, ski, or bicycle.",
-      "craig_durkin_bio_html": "Craig is the co-founder of <a href=\"http://www.concrete-jungle.org/\">Concrete Jungle</a>, an organization in Atlanta, Georgia which grows food and picks fruit throughout the city for donation to local homeless shelters and food banks. As a <a href=\"http://www.gatech.edu/\">Georgia Tech</a> graduate, he's always looking for ways to combine fruit picking with new technologies, and will soon be deploying his fruit-tree spotting drone and tweeting fruit-ripeness sensor...",
-      "emily_sigman_bio_html": "Emily is a diehard agroforestry evangelist, incorrigible forager, and proud mother to two cats, four quails, and the world's most magnificent canine. Her roots stretch deep into the Rocky Mountains, but these days her aboveground biomass is proud to call New Haven, Connecticut her home. She can often be found tending public food forests, reading enraptured in some cozy library corner, or waxing poetic about the magic of mycelium (and, supposedly, completing joint graduate degrees at the Yale <a href=\"https://environment.yale.edu/\">School of Forestry</a> and <a href=\"https://jackson.yale.edu/person/emily-sigman/\">School of Global Affairs</a>). Emily harbors a devastating addiction to travel, and could be just about anywhere right now.",
-      "advisors": "Board of advisors",
-      "alan_gibson_bio_html": "Alan has always enjoyed adventures and exploring. He began foraging as a way to introduce his young children to the outdoors lifestyle. He writes the <a href=\"http://theurbaneforager.blogspot.com\">Urbane Forager</a> blog and published the <a href=\"https://www.amazon.co.uk/Urbane-Forager-Fruit-Nuts-Free/dp/1785073001\">Urbane Forager: Fruit and Nuts For Free</a> book. He has legitimised foraging in public parks and established a community orchard in his home town, Southampton UK.",
-      "ana_carolina_bio_html": "Ana is a postdoctoral researcher at the Federal University of Pará in Brazil. She is an anthropologist interested in understanding social and cultural diet habits. Ana worked mostly in the Brazilian Amazon. In Acre (western Amazon) she studied regional fruit consumption. Then, she worked in the Middle Solimões region, investigating diet change in remote communities. Between 2017 and 2018, Ana lived in small and medium towns of the Amazon Delta, looking at the effects of climate change on the food security of people living in informal settlements. She recently moved to southern New Mexico in the United States, where she works as a consultant.",
-      "caleb_phillips_bio_html": "Caleb is a featherless bipedal humanoid passionate about food justice and finding creative ways to use technology to address social issues. When he's not biking around gawking at trees, he balances his efforts between his day job as a data scientist at the <a href=\"https://www.nrel.gov/research/caleb-phillips.html\">National Renewable Energy Laboratory</a> in Golden, Colorado and as an adjunct professor of computer science at the <a href=\"https://www.colorado.edu/cs/caleb-phillips\">University of Colorado</a>. Besides all that work stuff, he likes to climb rocks, run trails, ride bikes, and generally be outdoors as much as possible. Caleb created Falling Fruit with Ethan Welty in 2013 and served on the Board of Directors for 6 years before taking a position on the Advisory Board.",
-      "cristina_rubke_bio_html": "Cristina is an attorney with <a href=\"//sflaw.com/Bios/Rubke-Cristina-N.htm\">Shartsis Friese LLP</a> in San Francisco, California, where she focuses on trademark prosecution and counseling. She is also a board member of the <a href=\"//www.sfmta.com/\">San Francisco Municipal Transportation Agency</a>, which oversees public transportation, traffic and parking in San Francisco. In her spare time, Cristina sails the San Francisco Bay with the <a href=\"//www.baads.org/\">Bay Area Association of Disabled Sailors</a> and competes in local and international regattas.",
-      "david_craft_bio_html": "David is a researcher in the Department of Radiation Oncology at the <a href=\"//gray.mgh.harvard.edu/index.php?option=com_content&view=article&id=4:david-craft-phd&catid=1:f\">Harvard Medical School</a> in Boston, Massachusetts. He is also an avid forager and author of the book <a href=\"//www.amazon.com/Urban-Foraging-finding-eating-plants-ebook/dp/B003LSTEGO/\">Urban Foraging: Finding and Eating Wild Plants in the City</a> (<a href=\"/docs/David Craft - Urban Foraging.pdf\">free download</a>).",
-      "tristram_stuart_bio_html": "As a teenager, Tristram raised pigs on surplus food that he collected from his school kitchens, the local baker and village greengrocer. Noticing that a lot of this food was still suitable for human consumption led him to the realization that good, fresh food was being wasted on a colossal scale. Tristram has since worked tirelessly to bring this issue to the attention of the public, the media, and policy-makers. He founded the food waste campaign organization <a href=\"//feedbackglobal.org\">Feedback Global</a> and wrote <a href=\"//tristramstuart.co.uk/\">Waste: Uncovering the Global Food Scandal</a> to demonstrate the extent of the problem on a global scale. In 2011, Tristram was awarded <a href=\"//www.sofieprisen.no/Prize_Winners/2011/index.html\">The Sophie Prize</a> for his fight against food waste.",
-      "translators": "Translators",
-      "closing_remarks": "Closing remarks",
-      "closing_remarks_para1_html": "Falling Fruit is a 501(c)(3) (tax-exempt) public charity based in Boulder, Colorado. As a result, donations within the United States are tax deductible. You may review our <a href=\"/501c3.pdf\">letter of exemption</a> from the IRS and verify our standing with <a href=\"http://apps.irs.gov/app/eos/pub78Search.do?\">IRS Publication 78</a> or the <a href=\"http://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do?resetTransTyp=Y\">Colorado Secretary of State</a>. Also available are our <a href=\"https://docs.google.com/document/d/18E7PiiYbReq2c3BKYzxjHphiXsdtvkW-14UcN5y_5P4/edit?usp=sharing\">bylaws</a> and board meeting <a href=\"https://docs.google.com/document/d/1fzqYZ7rxYfeVqDuvI_uAyWhKm50RilqdTz6oxx3Ohw4\">minutes</a>.",
-      "closing_remarks_para2_html": "Harvesting food in an urban setting comes with certain practical and moral considerations. For an introduction to the ethics of urban foraging, we recommend the following <a href=\"https://docs.google.com/document/d/1SupIGQKC5Vgi3VYkdIQc05y_S7jSoZ4RTS-CzwlEAMY\">summary</a>.",
-      "closing_remarks_para3_html": "Information on Falling Fruit may be wrong or out of date. For example, many of the foraging maps migrated to Falling Fruit were hosted as public Google Maps on which markers were often moved accidentally, and municipal tree inventories are updated only (if ever) as trees are visited for maintenance. Be prepared to encounter inaccuracies in the field, and please edit the map as needed based on your discoveries. Ultimately, it is your responsibility to determine the identity, edibility, and location of a plant, and the responsibility of all to improve the quality of the map."
-    },
-    "sharing": {
-      "grow_pick_and_distribute": "Grow · Pick · Distribute",
-      "intro_html": "Listed below are organizations that grow food in public spaces (food forests, public orchards), pick food (urban foraging, farm gleaning), or distribute food (exchanges, donations). Organizations are listed by country, state (if applicable), and city. Those with crossed-out names are believed to be inactive. If you know of others that should be on this list, <a href=\"mailto:info@fallingfruit.org\">contact us</a>!"
-    },
-    "data": {
-      "intro": "Falling Fruit is built on public data and the generosity of our users. We want urban foraging to reach as many people as possible, and we believe that everyone should have equal access to the fruits of our collective labor. In the spirit of openness, behold! The entire database",
-      "beware_html": "But beware! Once uncompressed, the database is a huge file that will crush most spreadsheet software. If you only need data for a small region, first try retrieving them using the download tool integrated into the <a href=\"/\">map</a>.",
-      "license_html": "If you are interested in using the data in your project, especially a commercial project, we suggest you contact us (<a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a>). Unless otherwise specified, data are licensed as <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a> (Creative Commons – Attribution, Non-commercial, Share-alike). This means that you are free to use and distribute the data so long as you preserve the original author/source attributions and do not use it (without permission) for commercial applications. The source code for Falling Fruit is also open, and available on <a href=\"https://github.com/falling-fruit/\">GitHub</a>.",
-      "caveat_emptor_html": "We take no responsibility for the accuracy of the data - it is provided as is, <i>caveat emptor</i>. If you do something cool with the data, please <a href=\"mailto:feedback@fallingfruit.org\">let us know</a>!"
-    },
-    "datasets": {
-      "intro_html": "Falling Fruit aspires to be the most comprehensive and open geographic dataset of urban edibles. While our users explore, edit, and add locations using our <a href=\"/\">map</a>, we comb the known universe for pre-existing datasets and import them directly into the <a href=\"/data\">database</a>, uniting the efforts of foragers, foresters, and freegans everywhere. If you know of a dataset we've missed, please <a href=\"mailto:info@fallingfruit.org\">let us know</a>! You can also help us with the import process by formatting the data using the <a href=\"https://docs.google.com/spreadsheet/ccc?key=0AiHNFwLuWHvtdGVPamU2M0FZNFhpVTVSNXUtN3ZjRmc&usp=sharing\">import template</a>. Note that since imports must be performed manually, all changes to the original data made after the import are not reflected on Falling Fruit.",
-      "types_of_data": "Datasets imported into Falling Fruit fall into two main categories. \"Community maps\" are built by foragers and freegans as they peruse their communities for things to eat. We are indebted to the hardworking citizen-cartographers who have compiled this data. \"Tree inventories\" are compiled by cities, universities, and other institutions wishing to better document and care for their trees. We mine these vast datasets for food-producing species and add them to the map. To help us map your neighborhood fruit trees, contact your school or city urging them to share their tree inventory with us.",
-      "table_info": "Each dataset is listed by name, number of locations, and date imported. Expanding each row reveals further details about the data, the import process, and the license governing how the data may be used.",
-      "community_map": "Community map",
-      "type": "Type",
-      "date_imported": "Date imported"
-    }
-  },
-  "users": {
-    "sign_in": "Sign in",
-    "sign_out": "Sign out",
-    "remember_me": "Remember me",
-    "forgot_password": "Reset your password",
-    "resend_confirmation_instructions": "Resend confirmation instructions",
-    "password_confirmation": "Password confirmation",
-    "bio": "About you",
-    "send_password_instructions": "Send password reset instructions",
-    "new_password": "New password",
-    "new_password_confirmation": "New password confirmation",
-    "change_password": "Change my password",
-    "edit_account": "Edit account",
-    "current_password": "Current password",
-    "options": {
-      "announcements_email": "Receive emails with important announcements and opportunities (1-2 per year)"
-    }
-  },
   "form": {
     "button": {
       "reset": "Reset"
     },
     "error": {
       "confirmation": "Does not match original",
-      "too_short": "Minimum of {{min}} characters",
-      "missing_password": "Required to change email or password"
+      "missing_password": "Required to change email or password",
+      "too_short": "Minimum of {{min}} characters"
     }
   },
-  "devise": {
-    "registrations": {
-      "signed_up": "Welcome! You have signed up successfully.",
-      "update_needs_confirmation": "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address.",
-      "updated": "Your account has been updated successfully."
+  "glossary": {
+    "about": "About",
+    "access": "Access",
+    "account": "Account",
+    "activity": "Activity",
+    "add_source": "Add location",
+    "address": "Address",
+    "australia": "Australia",
+    "belgium": "Belgium",
+    "brazil": "Brazil",
+    "canada": "Canada",
+    "chile": "Chile",
+    "czechia": "Czechia",
+    "data": "Data",
+    "delete": "Delete",
+    "description": "Description",
+    "donate": "Donate",
+    "edit": "Edit",
+    "email": "Email",
+    "fiji": "Fiji",
+    "finland": "Finland",
+    "france": "France",
+    "germany": "Germany",
+    "greece": "Greece",
+    "imported_datasets": "Imported datasets",
+    "ireland": "Ireland",
+    "italy": "Italy",
+    "labels": "Labels",
+    "links": {
+      "one": "Link"
     },
-    "confirmations": {
-      "confirmed": "Your email address has been successfully confirmed.",
-      "send_instructions": "You will receive an email with instructions for how to confirm your email address in a few minutes.",
-      "no_token": "You can't access this page without coming from a confirmation email. If you do, please make sure you used the full URL provided."
+    "list": "List",
+    "locations": {
+      "other": "Locations"
     },
-    "passwords": {
-      "send_instructions": "You will receive an email with instructions on how to reset your password in a few minutes.",
-      "no_token": "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided.",
-      "updated_not_active": "Your password has been changed successfully."
+    "login": "Login",
+    "logout": "Logout",
+    "map": "Map",
+    "name": "Name",
+    "new_zealand": "New Zealand",
+    "password": "Password",
+    "portugal": "Portugal",
+    "position": "Position",
+    "quality": "Quality",
+    "report": "Report",
+    "save_changes": "Save changes",
+    "season": "Season",
+    "send": "Send",
+    "sign_up": "Sign up",
+    "spain": "Spain",
+    "submit": "Submit",
+    "sweden": "Sweden",
+    "switzerland": "Switzerland",
+    "tree_inventory": {
+      "one": "Tree inventory"
     },
-    "failure": {
-      "already_authenticated": "You are already signed in."
+    "types": "Types",
+    "united_kingdom": "United Kingdom",
+    "united_states": "United States",
+    "unverified": "Unverified",
+    "yield": "Yield"
+  },
+  "imperial": "Imperial",
+  "imported_from": "Imported from {{name}}",
+  "language": "Language",
+  "layouts": {
+    "application": {
+      "menu": {
+        "in_the_press": "In the press",
+        "sharing_the_harvest": "Sharing the harvest",
+        "the_data": "The data",
+        "the_project": "The project"
+      }
+    },
+    "page_title": {
+      "adding_location": "Adding Location",
+      "adding_review": "Adding Review",
+      "editing_location": "Editing Location",
+      "editing_review": "Editing Review"
     }
   },
   "locations": {
+    "form": {
+      "comments": "Comments",
+      "comments_subtext": "Updates, access issues, plant health...",
+      "description_subtext": "Location details, access issues, plant health ...",
+      "fruiting_status": "Fruiting status"
+    },
+    "index": {
+      "editmarker_html": "<b>Move to the position of the source.</b><br><br>Check the satellite view - the source may be visible from space!"
+    },
     "infowindow": {
-      "fruiting": ["Flowers", "Unripe fruit", "Ripe fruit"],
       "access_mode": [
         "Source is on my property",
         "I have permission from the owner to add the source",
@@ -219,38 +148,109 @@
         "Public",
         "Private but overhanging",
         "Private"
-      ]
-    },
-    "form": {
-      "comments_subtext": "Updates, access issues, plant health...",
-      "comments": "Comments",
-      "fruiting_status": "Fruiting status",
-      "description_subtext": "Location details, access issues, plant health ..."
-    },
-    "index": {
-      "editmarker_html": "<b>Move to the position of the source.</b><br><br>Check the satellite view - the source may be visible from space!"
+      ],
+      "fruiting": ["Flowers", "Unripe fruit", "Ripe fruit"]
     }
   },
-  "problems": {
-    "problem_type": "Problem type",
-    "description_subtext": "Any information that might help us evaluate the problem"
+  "menu": {
+    "zoom_in_to_add_location": "Zoom in to add location"
   },
-  "changes": {
-    "type": {
-      "added": "added",
-      "edited": "edited",
-      "grafted": "grafted",
-      "visited": "visited"
+  "metric": "Metric",
+  "only_on_map": "On the map",
+  "optional": "Optional",
+  "pages": {
+    "about": {
+      "about_the_site": "About the project",
+      "advisors": "Board of advisors",
+      "alan_gibson_bio_html": "Alan has always enjoyed adventures and exploring. He began foraging as a way to introduce his young children to the outdoors lifestyle. He writes the <a href=\"http://theurbaneforager.blogspot.com\">Urbane Forager</a> blog and published the <a href=\"https://www.amazon.co.uk/Urbane-Forager-Fruit-Nuts-Free/dp/1785073001\">Urbane Forager: Fruit and Nuts For Free</a> book. He has legitimised foraging in public parks and established a community orchard in his home town, Southampton UK.",
+      "ana_carolina_bio_html": "Ana is a postdoctoral researcher at the Federal University of Pará in Brazil. She is an anthropologist interested in understanding social and cultural diet habits. Ana worked mostly in the Brazilian Amazon. In Acre (western Amazon) she studied regional fruit consumption. Then, she worked in the Middle Solimões region, investigating diet change in remote communities. Between 2017 and 2018, Ana lived in small and medium towns of the Amazon Delta, looking at the effects of climate change on the food security of people living in informal settlements. She recently moved to southern New Mexico in the United States, where she works as a consultant.",
+      "caleb_phillips_bio_html": "Caleb is a featherless bipedal humanoid passionate about food justice and finding creative ways to use technology to address social issues. When he's not biking around gawking at trees, he balances his efforts between his day job as a data scientist at the <a href=\"https://www.nrel.gov/research/caleb-phillips.html\">National Renewable Energy Laboratory</a> in Golden, Colorado and as an adjunct professor of computer science at the <a href=\"https://www.colorado.edu/cs/caleb-phillips\">University of Colorado</a>. Besides all that work stuff, he likes to climb rocks, run trails, ride bikes, and generally be outdoors as much as possible. Caleb created Falling Fruit with Ethan Welty in 2013 and served on the Board of Directors for 6 years before taking a position on the Advisory Board.",
+      "celebration": "Falling Fruit is a celebration of the overlooked culinary bounty of our city streets. By quantifying this resource on an interactive map, we hope to facilitate intimate connections between people, food, and the natural organisms growing in our neighborhoods. Not just a free lunch! Foraging in the 21st century is an opportunity for urban exploration, to fight the scourge of stained sidewalks, and to reconnect with the botanical origins of food.",
+      "closing_remarks": "Closing remarks",
+      "closing_remarks_para1_html": "Falling Fruit is a 501(c)(3) (tax-exempt) public charity based in Boulder, Colorado. As a result, donations within the United States are tax deductible. You may review our <a href=\"/501c3.pdf\">letter of exemption</a> from the IRS and verify our standing with <a href=\"http://apps.irs.gov/app/eos/pub78Search.do?\">IRS Publication 78</a> or the <a href=\"http://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do?resetTransTyp=Y\">Colorado Secretary of State</a>. Also available are our <a href=\"https://docs.google.com/document/d/18E7PiiYbReq2c3BKYzxjHphiXsdtvkW-14UcN5y_5P4/edit?usp=sharing\">bylaws</a> and board meeting <a href=\"https://docs.google.com/document/d/1fzqYZ7rxYfeVqDuvI_uAyWhKm50RilqdTz6oxx3Ohw4\">minutes</a>.",
+      "closing_remarks_para2_html": "Harvesting food in an urban setting comes with certain practical and moral considerations. For an introduction to the ethics of urban foraging, we recommend the following <a href=\"https://docs.google.com/document/d/1SupIGQKC5Vgi3VYkdIQc05y_S7jSoZ4RTS-CzwlEAMY\">summary</a>.",
+      "closing_remarks_para3_html": "Information on Falling Fruit may be wrong or out of date. For example, many of the foraging maps migrated to Falling Fruit were hosted as public Google Maps on which markers were often moved accidentally, and municipal tree inventories are updated only (if ever) as trees are visited for maintenance. Be prepared to encounter inaccuracies in the field, and please edit the map as needed based on your discoveries. Ultimately, it is your responsibility to determine the identity, edibility, and location of a plant, and the responsibility of all to improve the quality of the map.",
+      "contact_us_html": "Falling Fruit is built by and for foragers – we want it to be the best tool available to the contemporary forager. Write us at <a href=\"mailto:feedback@fallingfruit.org\">feedback@fallingfruit.org</a>, we would love to hear from you!",
+      "craig_durkin_bio_html": "Craig is the co-founder of <a href=\"http://www.concrete-jungle.org/\">Concrete Jungle</a>, an organization in Atlanta, Georgia which grows food and picks fruit throughout the city for donation to local homeless shelters and food banks. As a <a href=\"http://www.gatech.edu/\">Georgia Tech</a> graduate, he's always looking for ways to combine fruit picking with new technologies, and will soon be deploying his fruit-tree spotting drone and tweeting fruit-ripeness sensor...",
+      "cristina_rubke_bio_html": "Cristina is an attorney with <a href=\"//sflaw.com/Bios/Rubke-Cristina-N.htm\">Shartsis Friese LLP</a> in San Francisco, California, where she focuses on trademark prosecution and counseling. She is also a board member of the <a href=\"//www.sfmta.com/\">San Francisco Municipal Transportation Agency</a>, which oversees public transportation, traffic and parking in San Francisco. In her spare time, Cristina sails the San Francisco Bay with the <a href=\"//www.baads.org/\">Bay Area Association of Disabled Sailors</a> and competes in local and international regattas.",
+      "david_craft_bio_html": "David is a researcher in the Department of Radiation Oncology at the <a href=\"//gray.mgh.harvard.edu/index.php?option=com_content&view=article&id=4:david-craft-phd&catid=1:f\">Harvard Medical School</a> in Boston, Massachusetts. He is also an avid forager and author of the book <a href=\"//www.amazon.com/Urban-Foraging-finding-eating-plants-ebook/dp/B003LSTEGO/\">Urban Foraging: Finding and Eating Wild Plants in the City</a> (<a href=\"/docs/David Craft - Urban Foraging.pdf\">free download</a>).",
+      "directors": "Board of directors",
+      "emily_sigman_bio_html": "Emily is a diehard agroforestry evangelist, incorrigible forager, and proud mother to two cats, four quails, and the world's most magnificent canine. Her roots stretch deep into the Rocky Mountains, but these days her aboveground biomass is proud to call New Haven, Connecticut her home. She can often be found tending public food forests, reading enraptured in some cozy library corner, or waxing poetic about the magic of mycelium (and, supposedly, completing joint graduate degrees at the Yale <a href=\"https://environment.yale.edu/\">School of Forestry</a> and <a href=\"https://jackson.yale.edu/person/emily-sigman/\">School of Global Affairs</a>). Emily harbors a devastating addiction to travel, and could be just about anywhere right now.",
+      "ethan_welty_bio_html": "With technology and data, Ethan champions cities as sources of fresh and free food. He created Falling Fruit with Caleb Phillips in 2013 to promote urban foraging worldwide, and co-founded <a href=\"https://fruitrescue.org\">Community Fruit Rescue</a> in 2014 to harvest and distribute surplus fruit growing around him in Boulder, Colorado. Beyond fruit, he juggles a <a href=\"https://www.weltyphotography.com\">photography career</a>, <a href=\"https://instaar.colorado.edu/people/ethan-welty/\">research on glaciers</a>, and an appetite for mountainous and riverine pursuits.",
+      "ff_disclaimer_html": "Falling Fruit is not associated with Fallen Fruit. Fallen Fruit can be found at <a href=\"http://fallenfruit.org\">fallenfruit.org</a>.",
+      "give_paypal": "Donate via Paypal Giving Fund",
+      "give_us_money": "We are a 501(c)(3) nonprofit and rely on donations to operate. If you are willing and able, please consider making a financial contribution. Donations within the United States are tax deductible.",
+      "jeff_wanner_bio_html": "Since harvesting black and blueberries with his family as a child and, more recently, noticing the wealth of public fruit trees throughout Colorado, Jeff has developed a deep appreciation for the abundance of fruit growing in our cities. His first mission for Falling Fruit was to comb Boulder and Salt Lake City, paper maps in-hand, to record fruiting trees. When not working to improve building energy efficiency, he is usually helping out in the community or moving quickly over mountains by foot, ski, or bicycle.",
+      "join_us_html": "Join us in celebrating hyper-local food! The <a href=\"/\">map</a> is open for anyone to edit, the database can be <a href=\"/data\">downloaded</a> with just one click, and <a href=\"https://github.com/falling-fruit/\">the code</a> is open-source. You are likewise encouraged to share the bounty with your fellow humans. Our <a href=\"/sharing\">sharing page</a> lists hundreds of local organizations - planting public orchards and food forests, picking otherwise-wasted fruits and vegetables from city trees and farmers' fields, and sharing with neighbors and the needy.",
+      "more_about_html": "Our edible map is not the first of its kind, but it aspires to be the world's most comprehensive. While our users contribute locations of their own, we comb the internet for pre-existing knowledge, seeking to unite the efforts of foragers, foresters, and freegans everywhere. The <a href=\"/datasets\">imported datasets</a> range from small neighborhood foraging maps to vast professionally-compiled tree inventories. This so far amounts to {{types}} different types of edibles (most, but not all, plant species) distributed over {{locations}} locations. Beyond the cultivated and commonplace to the exotic flavors of foreign plants and long-forgotten native plants, foraging in your neighborhood is a journey through time and across cultures.",
+      "staff": "Staff",
+      "translate": "Translate",
+      "translate_for_us_html": "Interested in volunteering as a translator? Email us and we'll invite you to join us on <a href=\"https://phrase.com\">Phrase</a>, where our translations are managed.",
+      "translators": "Translators",
+      "tristram_stuart_bio_html": "As a teenager, Tristram raised pigs on surplus food that he collected from his school kitchens, the local baker and village greengrocer. Noticing that a lot of this food was still suitable for human consumption led him to the realization that good, fresh food was being wasted on a colossal scale. Tristram has since worked tirelessly to bring this issue to the attention of the public, the media, and policy-makers. He founded the food waste campaign organization <a href=\"//feedbackglobal.org\">Feedback Global</a> and wrote <a href=\"//tristramstuart.co.uk/\">Waste: Uncovering the Global Food Scandal</a> to demonstrate the extent of the problem on a global scale. In 2011, Tristram was awarded <a href=\"//www.sofieprisen.no/Prize_Winners/2011/index.html\">The Sophie Prize</a> for his fight against food waste.",
+      "write": "Write"
     },
-    "change_in_city": "{{type}} in {{city}}",
-    "recent_changes": "Recent changes"
+    "data": {
+      "beware_html": "But beware! Once uncompressed, the database is a huge file that will crush most spreadsheet software. If you only need data for a small region, first try retrieving them using the download tool integrated into the <a href=\"/\">map</a>.",
+      "caveat_emptor_html": "We take no responsibility for the accuracy of the data - it is provided as is, <i>caveat emptor</i>. If you do something cool with the data, please <a href=\"mailto:feedback@fallingfruit.org\">let us know</a>!",
+      "intro": "Falling Fruit is built on public data and the generosity of our users. We want urban foraging to reach as many people as possible, and we believe that everyone should have equal access to the fruits of our collective labor. In the spirit of openness, behold! The entire database",
+      "license_html": "If you are interested in using the data in your project, especially a commercial project, we suggest you contact us (<a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a>). Unless otherwise specified, data are licensed as <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a> (Creative Commons – Attribution, Non-commercial, Share-alike). This means that you are free to use and distribute the data so long as you preserve the original author/source attributions and do not use it (without permission) for commercial applications. The source code for Falling Fruit is also open, and available on <a href=\"https://github.com/falling-fruit/\">GitHub</a>."
+    },
+    "datasets": {
+      "community_map": "Community map",
+      "date_imported": "Date imported",
+      "intro_html": "Falling Fruit aspires to be the most comprehensive and open geographic dataset of urban edibles. While our users explore, edit, and add locations using our <a href=\"/\">map</a>, we comb the known universe for pre-existing datasets and import them directly into the <a href=\"/data\">database</a>, uniting the efforts of foragers, foresters, and freegans everywhere. If you know of a dataset we've missed, please <a href=\"mailto:info@fallingfruit.org\">let us know</a>! You can also help us with the import process by formatting the data using the <a href=\"https://docs.google.com/spreadsheet/ccc?key=0AiHNFwLuWHvtdGVPamU2M0FZNFhpVTVSNXUtN3ZjRmc&usp=sharing\">import template</a>. Note that since imports must be performed manually, all changes to the original data made after the import are not reflected on Falling Fruit.",
+      "table_info": "Each dataset is listed by name, number of locations, and date imported. Expanding each row reveals further details about the data, the import process, and the license governing how the data may be used.",
+      "type": "Type",
+      "types_of_data": "Datasets imported into Falling Fruit fall into two main categories. \"Community maps\" are built by foragers and freegans as they peruse their communities for things to eat. We are indebted to the hardworking citizen-cartographers who have compiled this data. \"Tree inventories\" are compiled by cities, universities, and other institutions wishing to better document and care for their trees. We mine these vast datasets for food-producing species and add them to the map. To help us map your neighborhood fruit trees, contact your school or city urging them to share their tree inventory with us."
+    },
+    "sharing": {
+      "grow_pick_and_distribute": "Grow · Pick · Distribute",
+      "intro_html": "Listed below are organizations that grow food in public spaces (food forests, public orchards), pick food (urban foraging, farm gleaning), or distribute food (exchanges, donations). Organizations are listed by country, state (if applicable), and city. Those with crossed-out names are believed to be inactive. If you know of others that should be on this list, <a href=\"mailto:info@fallingfruit.org\">contact us</a>!"
+    }
+  },
+  "poi": "Points of interest",
+  "problems": {
+    "description_subtext": "Any information that might help us evaluate the problem",
+    "problem_type": "Problem type"
+  },
+  "required": "Required",
+  "roadmap": "Map",
+  "select_all": "Select all",
+  "settings": "Settings",
+  "side_menu": {
+    "bicycle": "Biking",
+    "regional": "Regional",
+    "satellite": "Satellite",
+    "terrain": "Terrain",
+    "transit": "Transit"
   },
   "time": {
-    "last_24_hours": "Last 24 hours",
     "days": {
-      "other": "{{count}} days",
-      "one": "{{count}} day"
+      "one": "{{count}} day",
+      "other": "{{count}} days"
     },
+    "last_24_hours": "Last 24 hours",
     "time_ago": "{{time}} ago"
+  },
+  "type": "Type",
+  "units": "Units",
+  "users": {
+    "bio": "About you",
+    "change_password": "Change my password",
+    "current_password": "Current password",
+    "edit_account": "Edit account",
+    "forgot_password": "Reset your password",
+    "new_password": "New password",
+    "new_password_confirmation": "New password confirmation",
+    "options": {
+      "announcements_email": "Receive emails with important announcements and opportunities (1-2 per year)"
+    },
+    "password_confirmation": "Password confirmation",
+    "remember_me": "Remember me",
+    "resend_confirmation_instructions": "Resend confirmation instructions",
+    "send_password_instructions": "Send password reset instructions",
+    "sign_in": "Sign in",
+    "sign_out": "Sign out"
   }
 }

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -144,6 +144,11 @@
       "fruiting": ["Fleurs", "Fruits pas mûrs", "Fruits mûrs"]
     }
   },
+  "menu": {
+    "add_location": "Ajouter un site",
+    "add_review": "Ajouter un avis",
+    "edit_location": "Éditer un site"
+  },
   "metric": "Métriques",
   "only_on_map": "Sur la carte",
   "optional": "Facultatif",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -1,200 +1,132 @@
 {
-  "language": "Langue",
-  "units": "Unités",
-  "metric": "Métriques",
-  "imperial": "Impériales",
-  "roadmap": "Plan",
-  "poi": "Points d'intérêt",
-  "settings": "Paramètres",
-  "type": "Type",
-  "select_all": "Sélectionner tous",
-  "deselect_all": "Désélectionner tous",
-  "only_on_map": "Sur la carte",
-  "required": "Obligatoire",
-  "optional": "Facultatif",
-  "back": "Retour",
   "added_by": "Ajouté par {{name}}",
-  "imported_from": "Importé de {{name}}",
+  "back": "Retour",
+  "changes": {
+    "change_in_city": "{{type}} à {{city}}",
+    "recent_changes": "Modifications récentes",
+    "type": {
+      "added": "ajouté",
+      "edited": "modifié",
+      "grafted": "greffé",
+      "visited": "visité"
+    }
+  },
+  "deselect_all": "Désélectionner tous",
+  "devise": {
+    "confirmations": {
+      "confirmed": "Votre compte a été validé. Vous êtes maintenant connecté.",
+      "no_token": "Vous ne pouvez pas accéder à cette page sans passer par un e-mail de validation. Si vous venez en effet d’un tel email, assurez-vous d’utiliser l’URL complète.",
+      "send_instructions": "Vous allez recevoir les instructions nécessaires à la validation de votre compte dans quelques minutes."
+    },
+    "failure": {
+      "already_authenticated": "Vous êtes déjà connecté."
+    },
+    "passwords": {
+      "no_token": "Vous ne pouvez pas accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si ce mail ne fonctionne pas, assurez-vous d’utiliser l’URL complète.",
+      "send_instructions": "Vous allez recevoir un email dans quelques instants avec les instructions pour réinitialiser votre mot de passe.",
+      "updated_not_active": "Votre mot de passe a été changé avec succès."
+    },
+    "registrations": {
+      "signed_up": "Bienvenue ! Votre inscription a bien été enregistrée.",
+      "update_needs_confirmation": "Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse e-mail. Veuillez consulter votre messagerie et cliquer sur le lien pour confirmer votre nouvelle adresse.",
+      "updated": "Votre compte a bien été mis à jour."
+    }
+  },
   "edited_on": "Modifié le {{date}}",
-  "glossary": {
-    "about": "À propos",
-    "list": "Liste",
-    "address": "Adresse",
-    "types": "Types",
-    "data": "Données",
-    "map": "Carte",
-    "labels": "Étiquettes",
-    "login": "Connexion",
-    "logout": "Déconnexion",
-    "sign_up": "S'inscrire",
-    "account": "Compte",
-    "email": "Email",
-    "password": "Mot de passe",
-    "name": "Nom",
-    "send": "Envoyer",
-    "save_changes": "Enregistrer vos modifications",
-    "edit": "Modifier",
-    "donate": "Contribuer",
-    "activity": "Activité",
-    "quality": "Qualité",
-    "yield": "Production",
-    "report": "Signaler",
-    "position": "Position",
-    "description": "Description",
-    "unverified": "Non vérifié",
-    "submit": "Soumettre",
-    "delete": "Supprimer",
-    "imported_datasets": "Données importées",
-    "tree_inventory": {
-      "one": "Inventaire d'arbres"
-    },
-    "locations": {
-      "other": "Endroits"
-    },
-    "links": {
-      "one": "Lien"
-    },
-    "australia": "Australie",
-    "belgium": "Belgique",
-    "canada": "Canada",
-    "chile": "Chili",
-    "fiji": "Fidji",
-    "finland": "Finlande",
-    "france": "France",
-    "germany": "Allemagne",
-    "greece": "Grèce",
-    "ireland": "Irlande",
-    "italy": "Italie",
-    "new_zealand": "Nouvelle Zélande",
-    "portugal": "Portugal",
-    "spain": "Espagne",
-    "sweden": "Suède",
-    "switzerland": "Suisse",
-    "united_kingdom": "Royaume-Uni",
-    "united_states": "États-Unis",
-    "season": "Saison",
-    "access": "Accès",
-    "add_source": "Ajouter un site"
-  },
-  "side_menu": {
-    "regional": "Régional",
-    "satellite": "Satellite",
-    "terrain": "Relief",
-    "bicycle": "À vélo",
-    "transit": "Transports en commun"
-  },
-  "layouts": {
-    "application": {
-      "menu": {
-        "the_project": "Le projet",
-        "the_data": "Les données",
-        "sharing_the_harvest": "Partager la récolte",
-        "in_the_press": "Dans la presse"
-      }
-    }
-  },
-  "pages": {
-    "about": {
-      "ff_disclaimer_html": "Falling Fruit n'est pas lié à Fallen Fruit. Fallen Fruit peut être consulté à <a href=\"http://fallenfruit.org\">fallenfruit.org</a>.",
-      "give_us_money": "Nous sommes un organisme caritatif à but non lucratif 501(c)(3) basé à Boulder (Colorado, États-Unis). Les dons réalisés depuis les États-Unis sont donc déductibles des impôts.",
-      "give_paypal": "Faire un don avec Paypal Giving Fund",
-      "write": "Écrire",
-      "contact_us_html": "Falling Fruit a été créé par et pour des glaneurs – nous voulons en faire le meilleur outil disponible pour les glaneurs modernes. Écrivez-nous à <a href=\"mailto:feedback@fallingfruit.org\">feedback@fallingfruit.org</a>, nous aimerions beaucoup avoir votre avis !",
-      "translate": "Traduire",
-      "translate_for_us_html": "Traduire bénévolement vous intéresse ? Envoyez-nous un e-mail et nous vous inviterons à nous rejoindre sur <a href=\"https://phrase.com\">Phrase</a>, où nous gérons nos traductions.",
-      "about_the_site": "À propos du projet",
-      "celebration": "Falling Fruit célèbre la richesse culinaire de nos rues, trop souvent oubliée.\nC’est en quantifiant cette ressource sur une carte interactive que nous espérons faciliter les liens entre les gens, la nourriture, et les organismes naturels qui poussent dans nos quartiers. Ce n’est pas qu’un repas gratuit ! Le glanage du XXIe siècle est une opportunité d’explorer la ville, d’affronter les horreurs des trottoirs souillés et de renouer avec les origines botaniques de la nourriture. ",
-      "more_about_html": "Notre carte des comestibles n’est pas la première, mais elle se veut la plus complète. Pendant que nos utilisateurs ajoutent leurs propres sites de glanage, nous passons Internet au peigne fin pour en trouver d’autres, en unissant les efforts des glaneurs, des forestiers et des freegans du monde entier. Les <a href=\"/datasets\">données importées</a> comprennent aussi bien des petites cartes de glanage de quartier que des inventaires professionnels d’arbres. À l’heure actuelle, notre application recense jusqu’à  {{types}} d’aliments comestibles différents (principalement des espèces végétales) réparties sur  {{locations}} sites. Les plantes les plus communes côtoient les plantes étrangères ou endémiques depuis longtemps oubliées. Le glanage, c’est un voyage dans le temps, une découverte de nouvelles cultures aux saveurs exotiques.",
-      "join_us_html": "Fan de nourriture hyperlocale ? Rejoignez-nous ! La <a href=\"/\">carte</a> est éditable par tout le monde, la base de données est <a href=\"/data\">téléchargeable</a> en un clic, et <a href=\"https://github.com/falling-fruit/\">le code</a> est en open source. Nous vous encourageons à faire de même en partageant votre récolte avec d’autres. Notre <a href=\"/sharing\">page de partages</a> liste des centaines d’associations locales qui plantent des vergers publics, des jardins-forêts, cueillent dans les arbres des villes et dans les champs de fermiers des fruit et légumes avant qu’ils ne soient jetés, pour les partager avec le voisinage ou les gens dans le besoin. ",
-      "staff": "Personnel",
-      "ethan_welty_bio_html": "Grâce à la technologie et aux données, Ethan défend les villes comme sources de nourriture fraîche et gratuite. Il a créé Falling Fruit avec Caleb Phillips en 2013 pour promouvoir la recherche de nourriture en milieu urbain dans le monde entier, et a cofondé <a href=\"https://fruitrescue.org\">Community Fruit Rescue</a> en 2014 pour récolter et distribuer les fruits excédentaires qui poussent autour de lui à Boulder, au Colorado. Au-delà des fruits, il jongle avec une <a href=\"https://www.weltyphotography.com\">carrière de photographe</a>, <a href=\"https://instaar.colorado.edu/people/ethan-welty/\">recherche sur les glaciers</a>, et un appétit pour les activités en montagne et sur les rivières.",
-      "directors": "Comité d'administration",
-      "jeff_wanner_bio_html": "C’est avec les premières récoltes de mûres et de myrtilles lorsqu’il était enfant et, plus récemment, après avoir remarqué la richesse des arbres fruitiers du Colorado, que Jeff a commencé à apprécier l’abondance des fruits qui poussent dans nos villes. Sa première mission pour Falling Fruit fut de passer Boulder et Salt Lake City au peigne fin, cartes en main, pour en noter tous les arbres fruitiers. \nLorsqu’il ne travaille pas à l’amélioration de l’efficacité énergétique d’un bâtiment, on peut le voir apporter son aide à la communauté, ou parcourir les montagnes à pieds, en ski, ou à vélo.",
-      "craig_durkin_bio_html": "Craig est le cofondateur de <a href=\"http://www.concrete-jungle.org/\">Concrete Jungle</a>, une organisation d’Atlanta (Géorgie, États-Unis) qui fait pousser de la nourriture et cueille des fruits à travers la ville pour en faire don à des foyers d’hébergement d’urgence et à des banques alimentaires. En tant que diplômé de <a href=\"http://www.gatech.edu/\">Georgia Tech</a>il est toujours à la recherche de nouvelles manières d’associer le glanage aux nouvelles technologies. Il va d’ailleurs bientôt lancer son drone chercheur d’arbres fruitiers et son détecteur de fruits mûrs...",
-      "emily_sigman_bio_html": "Emily est une ardente évangéliste de l'agroforesterie, une incorrigible butineuse et une fière mère de deux chats, quatre cailles et le plus magnifique des chiens du monde. Ses racines s'étendent profondément dans les montagnes Rocheuses, mais de nos jours, sa biomasse aérienne est fière d'appeler New Haven, Connecticut, sa maison. On peut souvent la trouver en train de s'occuper de forêts alimentaires publiques, de lire avec ravissement dans un coin de bibliothèque confortable, ou de faire de la poésie sur la magie du mycélium (et, soi-disant, de faire des études supérieures communes à la Yale <a href=\"https://environment.yale.edu/\">School of Forestry</a> et <a href=\"https://jackson.yale.edu/person/emily-sigman/\">School of Global Affairs</a>). Emily souffre d'une terrible dépendance aux voyages et pourrait être n'importe où en ce moment.",
-      "advisors": "Comité consultatif",
-      "alan_gibson_bio_html": "Alan a toujours aimé les aventures et l'exploration. Il a commencé à fouiller pour initier ses jeunes enfants au mode de vie en plein air. Il écrit le blog <a href=\"http://theurbaneforager.blogspot.com\">Urbane Forager</a> et a publié le <a href=\"https://www.amazon.co.uk/Urbane-Forager-Fruit-Nuts-Free/dp/1785073001\">Urbane Forager : Fruit and Nuts For Free</a> livre. Il a légitimé la recherche de nourriture dans les parcs publics et a créé un verger communautaire dans sa ville natale, Southampton, au Royaume-Uni.",
-      "ana_carolina_bio_html": "Ana est chercheuse postdoctorale à l'Université fédérale du Pará au Brésil. Elle est anthropologue et s'intéresse à la compréhension des habitudes alimentaires sociales et culturelles. Ana a travaillé principalement en Amazonie brésilienne. À Acre (Amazonie occidentale), elle a étudié la consommation régionale de fruits. Puis, elle a travaillé dans la région du Moyen Solimões, étudiant les changements de régime alimentaire dans les communautés isolées. Entre 2017 et 2018, Ana a vécu dans des petites et moyennes villes du delta de l'Amazone, étudiant les effets du changement climatique sur la sécurité alimentaire des personnes vivant dans des établissements informels. Elle s'est récemment installée dans le sud du Nouveau-Mexique aux États-Unis, où elle travaille comme consultante.",
-      "caleb_phillips_bio_html": "Caleb est un humanoïde bipède déplumé, passionné de justice alimentaire. Il adore aussi utiliser la technologie de manière créative pour résoudre les problèmes sociaux. Quand il ne fait pas des tours à vélo pour admirer les arbres fruitiers, Caleb travaille comme scientifique des données au <a href=\"http://nrel.gov\">National Renewable Energy Laboratory</a> à Golden, dans le Colorado(États-Unis), comme professeur adjoint en informatique à <a href=\"http://cs.colorado.edu\">l'Université du Colorado</a>, et comme abeille ouvrière pour plusieurs association à but non lucratif (<a href=\"http://www.foodrescuealliance.org/\">Food Rescue Alliance</a> à Denver et <a href=\"http://boulderfoodrescue.org\">Boulder Food Rescue</a> à Boulder, Colorado). Son temps libre, il le passe aussi à faire de l'escalade, de la course à pied, du vélo : il essaye de passer le plus de temps possible dans la nature.",
-      "cristina_rubke_bio_html": "Cristina est avocate chez <a href=\"//sflaw.com/Bios/Rubke-Cristina-N.htm\">Shartsis Friese LLP</a>, à San Francisco (Californie, États-Unis), où elle travaille dans le domaine du droit des marques et de la consultance juridique. Elle est aussi membre du conseil d’administration de la <a href=\"//www.sfmta.com/\">San Francisco Municipal Transportation Agency</a>(Agence des transports urbains de San Francisco), qui s’occupe des transports publics, de la circulation et du stationnement à San Francisco. Cristina profite de son temps libre pour naviguer sur la baie de San Francisco avec la <a href=\"//www.baads.org/\">Bay Area Association of Disabled Sailors</a> (Association des Navigateurs Handicapés de la Baie) et participe à des régates locales et internationales.",
-      "david_craft_bio_html": "David est chercheur au Département de Radiothérapie de <a href=\"//gray.mgh.harvard.edu/index.php?option=com_content&view=article&id=4:david-craft-phd&catid=1:f\">la Harvard Medical School</a> à Boston (Massachusetts, États-Unis). Il est aussi adepte du glanage et auteur du livre <a href=\"//www.amazon.com/Urban-Foraging-finding-eating-plants-ebook/dp/B003LSTEGO/\">Urban Foraging:Finding and Eating Wild Plants in the City</a> (<a href=”/docs/David Craft - Urban Foraging.pdf”>free download</a>).  ",
-      "tristram_stuart_bio_html": "Pendant son adolescence, Tristam élevait des cochons grâce au surplus alimentaire qu’il récupérait auprès des cuisines de son lycée, de la boulangerie du quartier et du marchand de légumes. C’est en remarquant que la majorité de ce surplus était propre à la consommation humaine qu’il a réalisé en quelle quantité était gâchée la nourriture, pourtant encore fraiche et bonne. Depuis, Tristam ne ménage pas ses efforts pour en informer le public, les médias et les décideurs politiques. C’est pour montrer l’envergure du problème qu’il a créé l’organisme de campagne contre le gaspillage alimentaire, <a href=\"//feedbackglobal.org\">Feedback Global</a> , et qu’il a écrit <a href=\"//tristramstuart.co.uk/\">Waste: Uncovering the Global Food Scandal</a>. En 2011, Tristam a reçu le <a href=\"//www.sofieprisen.no/Prize_Winners/2011/index.html\">prix Sophie</a> pour honorer son combat contre le gaspillage alimentaire.",
-      "translators": "Traducteurs",
-      "closing_remarks": "Dernières remarques",
-      "closing_remarks_para1_html": "Falling Fruit est un organisme caritatif à but non lucratif 501(c)(3) basé à Boulder (Colorado, États-Unis). Les dons réalisés depuis les États-Unis sont donc déductibles des impôts. Vous pouvez consulter notre <a href=\"/501c3.pdf\">certificat d’exemption</a> délivré par l’IRS et vérifier notre  conformité avec la loi avec <a href=\"http://apps.irs.gov/app/eos/pub78Search.do?\">la publication 78 de l’IRS</a> ou le <a href=\"http://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do?resetTransTyp=Y\">Secrétaire d’État au Colorado</a>. Nos <a href=\"https://docs.google.com/document/d/18E7PiiYbReq2c3BKYzxjHphiXsdtvkW-14UcN5y_5P4/edit?usp=sharing\">règlementations</a> et nos <a href=\"https://docs.google.com/document/d/1fzqYZ7rxYfeVqDuvI_uAyWhKm50RilqdTz6oxx3Ohw4\">procès-verbaux de conseil d’administration</a> sont également disponibles.",
-      "closing_remarks_para2_html": "Le glanage urbain a ses propres considérations pratiques et morales. Découvrez l’éthique du glanage urbain avec l’excellent résumé de notre site jumeau de Portland (Oregon, États-Unis),<a href=\"https://docs.google.com/document/d/1SupIGQKC5Vgi3VYkdIQc05y_S7jSoZ4RTS-CzwlEAMY\">Urban Edibles</a>.",
-      "closing_remarks_para3_html": "Les informations de Falling Fruit peuvent être incorrectes ou ne plus être valables. Par exemple : beaucoup des cartes de glanage ayant migré vers Falling Fruit étaient à l’origine des Google Maps dont les marqueurs étaient souvent déplacés par accident. Quant aux inventaires d’arbres municipaux, si mis à jour, ils le sont uniquement lorsque l’on procède à leur entretien. Les données peuvent s’avérer incorrectes une fois sur place, éditez alors la carte en fonction de vos découvertes. Il est de votre responsabilité à tous de déterminer la nature, la comestibilité et le site d’une plante, ainsi que d’améliorer la qualité de la carte."
-    },
-    "sharing": {
-      "grow_pick_and_distribute": "Cultiver · Récolter · Distribuer",
-      "intro_html": "Vous trouverez ci-dessous une liste des associations qui font pousser de la nourriture dans l’espace public (jardins-forêts, vergers publics), cueillent de la nourriture (glanage urbain, glanage en ferme) ou distribuent de la nourriture (troc, dons). Les associations sont classées par pays, état (si applicable) et ville. Celles dont les noms sont barrés sont supposées inactives. Si vous connaissez d’autres associations qui devraient être sur cette liste, <a href=\"mailto:info@fallingfruit.org\">contactez-nous</a>!"
-    },
-    "data": {
-      "intro": "C’est grâce à des bases de données publiques et à la générosité de nos utilisateurs que Falling Fruit existe. Nous voulons que le plus grand nombre de personnes possible découvre le glanage, et nous pensons que tout le monde doit avoir le même accès aux fruits de notre travail collectif. Dans cet esprit, voici notre base de données complète !",
-      "beware_html": "Attention! Une fois décompressées, les données deviennent un fichier énorme qui écrase la plupart des logiciels de tableur. Si vous recherchez seulement les données d'une zone limitée, essayez d'abord de récupérer les points d'intérêts avec l'outil de téléchargement intégré à la <a href=\"/\">carte</a>.",
-      "license_html": "Si vous souhaitez utiliser ces données dans le cadre d’un de vos projets, notamment un projet commercial, nous vous conseillons de nous contacter (<a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a>). Sauf indication contraire, les données sont sous licence <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a> (Creative Commons – Attribution, Pas d’utilisation commerciale, Partage dans les mêmes conditions). Cela signifie que vous être libre d’utiliser ou de distribuer ces données tant que vous créditez l’auteur/la source et que vous ne l’utilisez pas (sans permission) pour des projets commerciaux. Le code source de Falling Fruit est également ouvert et disponible à <a href=\"https://github.com/falling-fruit/\">GitHub</a>.",
-      "caveat_emptor_html": "Nous ne sommes pas responsables de la précision des données - elles sont fournies telles quelles, <i>caveat emptor</i>. Si vous faites quelque chose de cool avec ces données, <a href=\"mailto:feedback@fallingfruit.org\">faites-le nous savoir</a>!"
-    },
-    "datasets": {
-      "intro_html": "Falling Fruit aspire à devenir la plus complète et la plus ouverte des banques de données de plantes urbaines comestibles. Pendant que nos utilisateurs explorent, éditent et ajoutent des sites à notre <a href=\"/\">carte</a>, nous passons tout l’univers au peigne fin, à la recherche d’autres informations que nous ajoutons à notre <a href=\"/data\">base de données</a>, en unissant les efforts des glaneurs, des forestiers et des freegans du monde entier. Si vous voyez qu’il nous manque un ensemble de données, <a href=\"mailto:info@fallingfruit.org\">n’hésitez pas à nous contacter</a> ! Vous pouvez aussi nous aider avec le processus d’importation en formatant les données avec le <a href=\"https://docs.google.com/spreadsheet/ccc?key=0AiHNFwLuWHvtdGVPamU2M0FZNFhpVTVSNXUtN3ZjRmc&usp=sharing\">modèle d’importation</a>. Remarque : Sachant que les importations doivent être réalisées manuellement, les changements effectués sur les données d’origine après importation ne seront pas reportés sur Falling Fruit.",
-      "types_of_data": "Il y a deux catégories d’ensemble de données importés vers Falling Fruit : Les «cartes communautaires» sont créées par des glaneurs et les freegans qui fouillent leur communauté à la recherche de nourriture. Nous sommes très reconnaissants envers les citoyens-cartographes qui ont travaillé dur pour compiler ces données. Les «inventaires d’arbres» sont compilés par des villes, des universités et d’autres institutions qui cherchent à mieux documenter leurs arbres et à mieux s’en occuper. Nous parcourons ces larges bases de données à la recherche d’espèces qui produisent de la nourriture pour les ajouter à la carte. Aidez-nous à intégrer les arbres de votre voisinage à notre carte en contactant votre université ou votre ville pour leur demander de partager leurs inventaires d’arbres avec nous.",
-      "table_info": "Chaque ensemble de données est listé par nom, nombre de sites et date d’importation. En élargissant chaque ligne de données, vous verrez d’autres détails concernant les données, l’importation et la licence relative aux conditions d’utilisation de ces données.",
-      "community_map": "Cartes communautaires",
-      "type": "Type",
-      "date_imported": "Date d'importation"
-    }
-  },
-  "users": {
-    "sign_in": "Se connecter",
-    "sign_out": "Se déconnecter",
-    "remember_me": "Rester connecté",
-    "forgot_password": "Réinitialiser votre mot de passe",
-    "resend_confirmation_instructions": "Renvoyer les instructions de validation",
-    "password_confirmation": "Confirmation du mot de passe",
-    "bio": "Parlez-nous de vous",
-    "send_password_instructions": "Envoyer les instructions de réinitialisation de mot de passe",
-    "new_password": "Nouveau mot de passe",
-    "new_password_confirmation": "Confirmation du nouveau mot de passe",
-    "change_password": "Modifier mon mot de passe",
-    "edit_account": "Modifier mon compte",
-    "current_password": "Mot de passe actuel",
-    "options": {
-      "announcements_email": "Recevoir des e-mails pour des annonces importantes ou des opportunités (1 ou 2 fois par an)"
-    }
-  },
   "form": {
     "button": {
       "reset": "Réinitialiser"
     },
     "error": {
       "confirmation": "Ne correspond pas à l'original",
-      "too_short": "Minimum de {{min}} caractères",
-      "missing_password": "Requis pour changer d'email ou de mot de passe"
+      "missing_password": "Requis pour changer d'email ou de mot de passe",
+      "too_short": "Minimum de {{min}} caractères"
     }
   },
-  "devise": {
-    "registrations": {
-      "signed_up": "Bienvenue ! Votre inscription a bien été enregistrée.",
-      "update_needs_confirmation": "Votre compte a bien été mis à jour mais nous devons vérifier votre nouvelle adresse e-mail. Veuillez consulter votre messagerie et cliquer sur le lien pour confirmer votre nouvelle adresse.",
-      "updated": "Votre compte a bien été mis à jour."
+  "glossary": {
+    "about": "À propos",
+    "access": "Accès",
+    "account": "Compte",
+    "activity": "Activité",
+    "add_source": "Ajouter un site",
+    "address": "Adresse",
+    "australia": "Australie",
+    "belgium": "Belgique",
+    "canada": "Canada",
+    "chile": "Chili",
+    "data": "Données",
+    "delete": "Supprimer",
+    "description": "Description",
+    "donate": "Contribuer",
+    "edit": "Modifier",
+    "email": "Email",
+    "fiji": "Fidji",
+    "finland": "Finlande",
+    "france": "France",
+    "germany": "Allemagne",
+    "greece": "Grèce",
+    "imported_datasets": "Données importées",
+    "ireland": "Irlande",
+    "italy": "Italie",
+    "labels": "Étiquettes",
+    "links": {
+      "one": "Lien"
     },
-    "confirmations": {
-      "confirmed": "Votre compte a été validé. Vous êtes maintenant connecté.",
-      "send_instructions": "Vous allez recevoir les instructions nécessaires à la validation de votre compte dans quelques minutes.",
-      "no_token": "Vous ne pouvez pas accéder à cette page sans passer par un e-mail de validation. Si vous venez en effet d’un tel email, assurez-vous d’utiliser l’URL complète."
+    "list": "Liste",
+    "locations": {
+      "other": "Endroits"
     },
-    "passwords": {
-      "send_instructions": "Vous allez recevoir un email dans quelques instants avec les instructions pour réinitialiser votre mot de passe.",
-      "no_token": "Vous ne pouvez pas accéder à cette page sans passer par un e-mail de réinitialisation de mot de passe. Si ce mail ne fonctionne pas, assurez-vous d’utiliser l’URL complète.",
-      "updated_not_active": "Votre mot de passe a été changé avec succès."
+    "login": "Connexion",
+    "logout": "Déconnexion",
+    "map": "Carte",
+    "name": "Nom",
+    "new_zealand": "Nouvelle Zélande",
+    "password": "Mot de passe",
+    "portugal": "Portugal",
+    "position": "Position",
+    "quality": "Qualité",
+    "report": "Signaler",
+    "save_changes": "Enregistrer vos modifications",
+    "season": "Saison",
+    "send": "Envoyer",
+    "sign_up": "S'inscrire",
+    "spain": "Espagne",
+    "submit": "Soumettre",
+    "sweden": "Suède",
+    "switzerland": "Suisse",
+    "tree_inventory": {
+      "one": "Inventaire d'arbres"
     },
-    "failure": {
-      "already_authenticated": "Vous êtes déjà connecté."
+    "types": "Types",
+    "united_kingdom": "Royaume-Uni",
+    "united_states": "États-Unis",
+    "unverified": "Non vérifié",
+    "yield": "Production"
+  },
+  "imperial": "Impériales",
+  "imported_from": "Importé de {{name}}",
+  "language": "Langue",
+  "layouts": {
+    "application": {
+      "menu": {
+        "in_the_press": "Dans la presse",
+        "sharing_the_harvest": "Partager la récolte",
+        "the_data": "Les données",
+        "the_project": "Le projet"
+      }
     }
   },
   "locations": {
+    "form": {
+      "comments": "Commentaires",
+      "comments_subtext": "Nouveaux développements, problèmes d'accès, condition des plantes ...",
+      "description_subtext": "Détails, problèmes d'accès, condition des plantes ...",
+      "fruiting_status": "État des fruits"
+    },
+    "index": {
+      "editmarker_html": "<b>Déplacez à la position de la source.</b><br><br>Vérifiez la vue satellite - la source pourrait être visible depuis l'espace !"
+    },
     "infowindow": {
-      "fruiting": ["Fleurs", "Fruits pas mûrs", "Fruits mûrs"],
       "access_mode": [
         "La source m'appartient",
         "J'ai la permission du propriétaire d'ajouté la source",
@@ -208,38 +140,106 @@
         "Public",
         "Privé mais en surplomb",
         "Privé"
-      ]
-    },
-    "form": {
-      "comments_subtext": "Nouveaux développements, problèmes d'accès, condition des plantes ...",
-      "comments": "Commentaires",
-      "fruiting_status": "État des fruits",
-      "description_subtext": "Détails, problèmes d'accès, condition des plantes ..."
-    },
-    "index": {
-      "editmarker_html": "<b>Déplacez à la position de la source.</b><br><br>Vérifiez la vue satellite - la source pourrait être visible depuis l'espace !"
+      ],
+      "fruiting": ["Fleurs", "Fruits pas mûrs", "Fruits mûrs"]
     }
   },
-  "problems": {
-    "problem_type": "Type de problème",
-    "description_subtext": "Toute information pouvant nous aider à évaluer le problème"
-  },
-  "changes": {
-    "type": {
-      "added": "ajouté",
-      "edited": "modifié",
-      "grafted": "greffé",
-      "visited": "visité"
+  "metric": "Métriques",
+  "only_on_map": "Sur la carte",
+  "optional": "Facultatif",
+  "pages": {
+    "about": {
+      "about_the_site": "À propos du projet",
+      "advisors": "Comité consultatif",
+      "alan_gibson_bio_html": "Alan a toujours aimé les aventures et l'exploration. Il a commencé à fouiller pour initier ses jeunes enfants au mode de vie en plein air. Il écrit le blog <a href=\"http://theurbaneforager.blogspot.com\">Urbane Forager</a> et a publié le <a href=\"https://www.amazon.co.uk/Urbane-Forager-Fruit-Nuts-Free/dp/1785073001\">Urbane Forager : Fruit and Nuts For Free</a> livre. Il a légitimé la recherche de nourriture dans les parcs publics et a créé un verger communautaire dans sa ville natale, Southampton, au Royaume-Uni.",
+      "ana_carolina_bio_html": "Ana est chercheuse postdoctorale à l'Université fédérale du Pará au Brésil. Elle est anthropologue et s'intéresse à la compréhension des habitudes alimentaires sociales et culturelles. Ana a travaillé principalement en Amazonie brésilienne. À Acre (Amazonie occidentale), elle a étudié la consommation régionale de fruits. Puis, elle a travaillé dans la région du Moyen Solimões, étudiant les changements de régime alimentaire dans les communautés isolées. Entre 2017 et 2018, Ana a vécu dans des petites et moyennes villes du delta de l'Amazone, étudiant les effets du changement climatique sur la sécurité alimentaire des personnes vivant dans des établissements informels. Elle s'est récemment installée dans le sud du Nouveau-Mexique aux États-Unis, où elle travaille comme consultante.",
+      "caleb_phillips_bio_html": "Caleb est un humanoïde bipède déplumé, passionné de justice alimentaire. Il adore aussi utiliser la technologie de manière créative pour résoudre les problèmes sociaux. Quand il ne fait pas des tours à vélo pour admirer les arbres fruitiers, Caleb travaille comme scientifique des données au <a href=\"http://nrel.gov\">National Renewable Energy Laboratory</a> à Golden, dans le Colorado(États-Unis), comme professeur adjoint en informatique à <a href=\"http://cs.colorado.edu\">l'Université du Colorado</a>, et comme abeille ouvrière pour plusieurs association à but non lucratif (<a href=\"http://www.foodrescuealliance.org/\">Food Rescue Alliance</a> à Denver et <a href=\"http://boulderfoodrescue.org\">Boulder Food Rescue</a> à Boulder, Colorado). Son temps libre, il le passe aussi à faire de l'escalade, de la course à pied, du vélo : il essaye de passer le plus de temps possible dans la nature.",
+      "celebration": "Falling Fruit célèbre la richesse culinaire de nos rues, trop souvent oubliée.\nC’est en quantifiant cette ressource sur une carte interactive que nous espérons faciliter les liens entre les gens, la nourriture, et les organismes naturels qui poussent dans nos quartiers. Ce n’est pas qu’un repas gratuit ! Le glanage du XXIe siècle est une opportunité d’explorer la ville, d’affronter les horreurs des trottoirs souillés et de renouer avec les origines botaniques de la nourriture. ",
+      "closing_remarks": "Dernières remarques",
+      "closing_remarks_para1_html": "Falling Fruit est un organisme caritatif à but non lucratif 501(c)(3) basé à Boulder (Colorado, États-Unis). Les dons réalisés depuis les États-Unis sont donc déductibles des impôts. Vous pouvez consulter notre <a href=\"/501c3.pdf\">certificat d’exemption</a> délivré par l’IRS et vérifier notre  conformité avec la loi avec <a href=\"http://apps.irs.gov/app/eos/pub78Search.do?\">la publication 78 de l’IRS</a> ou le <a href=\"http://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do?resetTransTyp=Y\">Secrétaire d’État au Colorado</a>. Nos <a href=\"https://docs.google.com/document/d/18E7PiiYbReq2c3BKYzxjHphiXsdtvkW-14UcN5y_5P4/edit?usp=sharing\">règlementations</a> et nos <a href=\"https://docs.google.com/document/d/1fzqYZ7rxYfeVqDuvI_uAyWhKm50RilqdTz6oxx3Ohw4\">procès-verbaux de conseil d’administration</a> sont également disponibles.",
+      "closing_remarks_para2_html": "Le glanage urbain a ses propres considérations pratiques et morales. Découvrez l’éthique du glanage urbain avec l’excellent résumé de notre site jumeau de Portland (Oregon, États-Unis),<a href=\"https://docs.google.com/document/d/1SupIGQKC5Vgi3VYkdIQc05y_S7jSoZ4RTS-CzwlEAMY\">Urban Edibles</a>.",
+      "closing_remarks_para3_html": "Les informations de Falling Fruit peuvent être incorrectes ou ne plus être valables. Par exemple : beaucoup des cartes de glanage ayant migré vers Falling Fruit étaient à l’origine des Google Maps dont les marqueurs étaient souvent déplacés par accident. Quant aux inventaires d’arbres municipaux, si mis à jour, ils le sont uniquement lorsque l’on procède à leur entretien. Les données peuvent s’avérer incorrectes une fois sur place, éditez alors la carte en fonction de vos découvertes. Il est de votre responsabilité à tous de déterminer la nature, la comestibilité et le site d’une plante, ainsi que d’améliorer la qualité de la carte.",
+      "contact_us_html": "Falling Fruit a été créé par et pour des glaneurs – nous voulons en faire le meilleur outil disponible pour les glaneurs modernes. Écrivez-nous à <a href=\"mailto:feedback@fallingfruit.org\">feedback@fallingfruit.org</a>, nous aimerions beaucoup avoir votre avis !",
+      "craig_durkin_bio_html": "Craig est le cofondateur de <a href=\"http://www.concrete-jungle.org/\">Concrete Jungle</a>, une organisation d’Atlanta (Géorgie, États-Unis) qui fait pousser de la nourriture et cueille des fruits à travers la ville pour en faire don à des foyers d’hébergement d’urgence et à des banques alimentaires. En tant que diplômé de <a href=\"http://www.gatech.edu/\">Georgia Tech</a>il est toujours à la recherche de nouvelles manières d’associer le glanage aux nouvelles technologies. Il va d’ailleurs bientôt lancer son drone chercheur d’arbres fruitiers et son détecteur de fruits mûrs...",
+      "cristina_rubke_bio_html": "Cristina est avocate chez <a href=\"//sflaw.com/Bios/Rubke-Cristina-N.htm\">Shartsis Friese LLP</a>, à San Francisco (Californie, États-Unis), où elle travaille dans le domaine du droit des marques et de la consultance juridique. Elle est aussi membre du conseil d’administration de la <a href=\"//www.sfmta.com/\">San Francisco Municipal Transportation Agency</a>(Agence des transports urbains de San Francisco), qui s’occupe des transports publics, de la circulation et du stationnement à San Francisco. Cristina profite de son temps libre pour naviguer sur la baie de San Francisco avec la <a href=\"//www.baads.org/\">Bay Area Association of Disabled Sailors</a> (Association des Navigateurs Handicapés de la Baie) et participe à des régates locales et internationales.",
+      "david_craft_bio_html": "David est chercheur au Département de Radiothérapie de <a href=\"//gray.mgh.harvard.edu/index.php?option=com_content&view=article&id=4:david-craft-phd&catid=1:f\">la Harvard Medical School</a> à Boston (Massachusetts, États-Unis). Il est aussi adepte du glanage et auteur du livre <a href=\"//www.amazon.com/Urban-Foraging-finding-eating-plants-ebook/dp/B003LSTEGO/\">Urban Foraging:Finding and Eating Wild Plants in the City</a> (<a href=”/docs/David Craft - Urban Foraging.pdf”>free download</a>).  ",
+      "directors": "Comité d'administration",
+      "emily_sigman_bio_html": "Emily est une ardente évangéliste de l'agroforesterie, une incorrigible butineuse et une fière mère de deux chats, quatre cailles et le plus magnifique des chiens du monde. Ses racines s'étendent profondément dans les montagnes Rocheuses, mais de nos jours, sa biomasse aérienne est fière d'appeler New Haven, Connecticut, sa maison. On peut souvent la trouver en train de s'occuper de forêts alimentaires publiques, de lire avec ravissement dans un coin de bibliothèque confortable, ou de faire de la poésie sur la magie du mycélium (et, soi-disant, de faire des études supérieures communes à la Yale <a href=\"https://environment.yale.edu/\">School of Forestry</a> et <a href=\"https://jackson.yale.edu/person/emily-sigman/\">School of Global Affairs</a>). Emily souffre d'une terrible dépendance aux voyages et pourrait être n'importe où en ce moment.",
+      "ethan_welty_bio_html": "Grâce à la technologie et aux données, Ethan défend les villes comme sources de nourriture fraîche et gratuite. Il a créé Falling Fruit avec Caleb Phillips en 2013 pour promouvoir la recherche de nourriture en milieu urbain dans le monde entier, et a cofondé <a href=\"https://fruitrescue.org\">Community Fruit Rescue</a> en 2014 pour récolter et distribuer les fruits excédentaires qui poussent autour de lui à Boulder, au Colorado. Au-delà des fruits, il jongle avec une <a href=\"https://www.weltyphotography.com\">carrière de photographe</a>, <a href=\"https://instaar.colorado.edu/people/ethan-welty/\">recherche sur les glaciers</a>, et un appétit pour les activités en montagne et sur les rivières.",
+      "ff_disclaimer_html": "Falling Fruit n'est pas lié à Fallen Fruit. Fallen Fruit peut être consulté à <a href=\"http://fallenfruit.org\">fallenfruit.org</a>.",
+      "give_paypal": "Faire un don avec Paypal Giving Fund",
+      "give_us_money": "Nous sommes un organisme caritatif à but non lucratif 501(c)(3) basé à Boulder (Colorado, États-Unis). Les dons réalisés depuis les États-Unis sont donc déductibles des impôts.",
+      "jeff_wanner_bio_html": "C’est avec les premières récoltes de mûres et de myrtilles lorsqu’il était enfant et, plus récemment, après avoir remarqué la richesse des arbres fruitiers du Colorado, que Jeff a commencé à apprécier l’abondance des fruits qui poussent dans nos villes. Sa première mission pour Falling Fruit fut de passer Boulder et Salt Lake City au peigne fin, cartes en main, pour en noter tous les arbres fruitiers. \nLorsqu’il ne travaille pas à l’amélioration de l’efficacité énergétique d’un bâtiment, on peut le voir apporter son aide à la communauté, ou parcourir les montagnes à pieds, en ski, ou à vélo.",
+      "join_us_html": "Fan de nourriture hyperlocale ? Rejoignez-nous ! La <a href=\"/\">carte</a> est éditable par tout le monde, la base de données est <a href=\"/data\">téléchargeable</a> en un clic, et <a href=\"https://github.com/falling-fruit/\">le code</a> est en open source. Nous vous encourageons à faire de même en partageant votre récolte avec d’autres. Notre <a href=\"/sharing\">page de partages</a> liste des centaines d’associations locales qui plantent des vergers publics, des jardins-forêts, cueillent dans les arbres des villes et dans les champs de fermiers des fruit et légumes avant qu’ils ne soient jetés, pour les partager avec le voisinage ou les gens dans le besoin. ",
+      "more_about_html": "Notre carte des comestibles n’est pas la première, mais elle se veut la plus complète. Pendant que nos utilisateurs ajoutent leurs propres sites de glanage, nous passons Internet au peigne fin pour en trouver d’autres, en unissant les efforts des glaneurs, des forestiers et des freegans du monde entier. Les <a href=\"/datasets\">données importées</a> comprennent aussi bien des petites cartes de glanage de quartier que des inventaires professionnels d’arbres. À l’heure actuelle, notre application recense jusqu’à  {{types}} d’aliments comestibles différents (principalement des espèces végétales) réparties sur  {{locations}} sites. Les plantes les plus communes côtoient les plantes étrangères ou endémiques depuis longtemps oubliées. Le glanage, c’est un voyage dans le temps, une découverte de nouvelles cultures aux saveurs exotiques.",
+      "staff": "Personnel",
+      "translate": "Traduire",
+      "translate_for_us_html": "Traduire bénévolement vous intéresse ? Envoyez-nous un e-mail et nous vous inviterons à nous rejoindre sur <a href=\"https://phrase.com\">Phrase</a>, où nous gérons nos traductions.",
+      "translators": "Traducteurs",
+      "tristram_stuart_bio_html": "Pendant son adolescence, Tristam élevait des cochons grâce au surplus alimentaire qu’il récupérait auprès des cuisines de son lycée, de la boulangerie du quartier et du marchand de légumes. C’est en remarquant que la majorité de ce surplus était propre à la consommation humaine qu’il a réalisé en quelle quantité était gâchée la nourriture, pourtant encore fraiche et bonne. Depuis, Tristam ne ménage pas ses efforts pour en informer le public, les médias et les décideurs politiques. C’est pour montrer l’envergure du problème qu’il a créé l’organisme de campagne contre le gaspillage alimentaire, <a href=\"//feedbackglobal.org\">Feedback Global</a> , et qu’il a écrit <a href=\"//tristramstuart.co.uk/\">Waste: Uncovering the Global Food Scandal</a>. En 2011, Tristam a reçu le <a href=\"//www.sofieprisen.no/Prize_Winners/2011/index.html\">prix Sophie</a> pour honorer son combat contre le gaspillage alimentaire.",
+      "write": "Écrire"
     },
-    "change_in_city": "{{type}} à {{city}}",
-    "recent_changes": "Modifications récentes"
+    "data": {
+      "beware_html": "Attention! Une fois décompressées, les données deviennent un fichier énorme qui écrase la plupart des logiciels de tableur. Si vous recherchez seulement les données d'une zone limitée, essayez d'abord de récupérer les points d'intérêts avec l'outil de téléchargement intégré à la <a href=\"/\">carte</a>.",
+      "caveat_emptor_html": "Nous ne sommes pas responsables de la précision des données - elles sont fournies telles quelles, <i>caveat emptor</i>. Si vous faites quelque chose de cool avec ces données, <a href=\"mailto:feedback@fallingfruit.org\">faites-le nous savoir</a>!",
+      "intro": "C’est grâce à des bases de données publiques et à la générosité de nos utilisateurs que Falling Fruit existe. Nous voulons que le plus grand nombre de personnes possible découvre le glanage, et nous pensons que tout le monde doit avoir le même accès aux fruits de notre travail collectif. Dans cet esprit, voici notre base de données complète !",
+      "license_html": "Si vous souhaitez utiliser ces données dans le cadre d’un de vos projets, notamment un projet commercial, nous vous conseillons de nous contacter (<a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a>). Sauf indication contraire, les données sont sous licence <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a> (Creative Commons – Attribution, Pas d’utilisation commerciale, Partage dans les mêmes conditions). Cela signifie que vous être libre d’utiliser ou de distribuer ces données tant que vous créditez l’auteur/la source et que vous ne l’utilisez pas (sans permission) pour des projets commerciaux. Le code source de Falling Fruit est également ouvert et disponible à <a href=\"https://github.com/falling-fruit/\">GitHub</a>."
+    },
+    "datasets": {
+      "community_map": "Cartes communautaires",
+      "date_imported": "Date d'importation",
+      "intro_html": "Falling Fruit aspire à devenir la plus complète et la plus ouverte des banques de données de plantes urbaines comestibles. Pendant que nos utilisateurs explorent, éditent et ajoutent des sites à notre <a href=\"/\">carte</a>, nous passons tout l’univers au peigne fin, à la recherche d’autres informations que nous ajoutons à notre <a href=\"/data\">base de données</a>, en unissant les efforts des glaneurs, des forestiers et des freegans du monde entier. Si vous voyez qu’il nous manque un ensemble de données, <a href=\"mailto:info@fallingfruit.org\">n’hésitez pas à nous contacter</a> ! Vous pouvez aussi nous aider avec le processus d’importation en formatant les données avec le <a href=\"https://docs.google.com/spreadsheet/ccc?key=0AiHNFwLuWHvtdGVPamU2M0FZNFhpVTVSNXUtN3ZjRmc&usp=sharing\">modèle d’importation</a>. Remarque : Sachant que les importations doivent être réalisées manuellement, les changements effectués sur les données d’origine après importation ne seront pas reportés sur Falling Fruit.",
+      "table_info": "Chaque ensemble de données est listé par nom, nombre de sites et date d’importation. En élargissant chaque ligne de données, vous verrez d’autres détails concernant les données, l’importation et la licence relative aux conditions d’utilisation de ces données.",
+      "type": "Type",
+      "types_of_data": "Il y a deux catégories d’ensemble de données importés vers Falling Fruit : Les «cartes communautaires» sont créées par des glaneurs et les freegans qui fouillent leur communauté à la recherche de nourriture. Nous sommes très reconnaissants envers les citoyens-cartographes qui ont travaillé dur pour compiler ces données. Les «inventaires d’arbres» sont compilés par des villes, des universités et d’autres institutions qui cherchent à mieux documenter leurs arbres et à mieux s’en occuper. Nous parcourons ces larges bases de données à la recherche d’espèces qui produisent de la nourriture pour les ajouter à la carte. Aidez-nous à intégrer les arbres de votre voisinage à notre carte en contactant votre université ou votre ville pour leur demander de partager leurs inventaires d’arbres avec nous."
+    },
+    "sharing": {
+      "grow_pick_and_distribute": "Cultiver · Récolter · Distribuer",
+      "intro_html": "Vous trouverez ci-dessous une liste des associations qui font pousser de la nourriture dans l’espace public (jardins-forêts, vergers publics), cueillent de la nourriture (glanage urbain, glanage en ferme) ou distribuent de la nourriture (troc, dons). Les associations sont classées par pays, état (si applicable) et ville. Celles dont les noms sont barrés sont supposées inactives. Si vous connaissez d’autres associations qui devraient être sur cette liste, <a href=\"mailto:info@fallingfruit.org\">contactez-nous</a>!"
+    }
+  },
+  "poi": "Points d'intérêt",
+  "problems": {
+    "description_subtext": "Toute information pouvant nous aider à évaluer le problème",
+    "problem_type": "Type de problème"
+  },
+  "required": "Obligatoire",
+  "roadmap": "Plan",
+  "select_all": "Sélectionner tous",
+  "settings": "Paramètres",
+  "side_menu": {
+    "bicycle": "À vélo",
+    "regional": "Régional",
+    "satellite": "Satellite",
+    "terrain": "Relief",
+    "transit": "Transports en commun"
   },
   "time": {
-    "last_24_hours": "Dernières 24 heures",
     "days": {
-      "other": "{{count}} jours",
-      "one": "{{count}} jour"
+      "one": "{{count}} jour",
+      "other": "{{count}} jours"
     },
+    "last_24_hours": "Dernières 24 heures",
     "time_ago": "Il y a {{time}}"
+  },
+  "type": "Type",
+  "units": "Unités",
+  "users": {
+    "bio": "Parlez-nous de vous",
+    "change_password": "Modifier mon mot de passe",
+    "current_password": "Mot de passe actuel",
+    "edit_account": "Modifier mon compte",
+    "forgot_password": "Réinitialiser votre mot de passe",
+    "new_password": "Nouveau mot de passe",
+    "new_password_confirmation": "Confirmation du nouveau mot de passe",
+    "options": {
+      "announcements_email": "Recevoir des e-mails pour des annonces importantes ou des opportunités (1 ou 2 fois par an)"
+    },
+    "password_confirmation": "Confirmation du mot de passe",
+    "remember_me": "Rester connecté",
+    "resend_confirmation_instructions": "Renvoyer les instructions de validation",
+    "send_password_instructions": "Envoyer les instructions de réinitialisation de mot de passe",
+    "sign_in": "Se connecter",
+    "sign_out": "Se déconnecter"
   }
 }

--- a/src/components/form/formRoutes.js
+++ b/src/components/form/formRoutes.js
@@ -30,17 +30,13 @@ const Header = styled.h3`
   margin-left: 10px;
 `
 
-const MobileNav = ({ titleKey, onBack }) => {
-  const { t } = useTranslation()
+const MobileNav = ({ title, onBack }) => (
+  <TopBar>
+    <TopBarNav onBack={onBack} title={title} />
+  </TopBar>
+)
 
-  return (
-    <TopBar>
-      <TopBarNav onBack={onBack} title={t(titleKey)} />
-    </TopBar>
-  )
-}
-
-const DesktopNav = ({ titleKey, onBack }) => {
+const DesktopNav = ({ title, onBack }) => {
   const { t } = useTranslation()
   return (
     <>
@@ -50,7 +46,7 @@ const DesktopNav = ({ titleKey, onBack }) => {
           {t('back')}
         </BackButton>
       </StyledNavBack>
-      <Header>{t(titleKey)}</Header>
+      <Header>{title}</Header>
     </>
   )
 }
@@ -58,11 +54,12 @@ const DesktopNav = ({ titleKey, onBack }) => {
 const EditLocation = ({ NavComponent }) => {
   const history = useAppHistory()
   const { locationId } = useParams()
+  const { t } = useTranslation()
 
   return (
     <>
       <NavComponent
-        titleKey="layouts.page_title.editing_location"
+        title={t('menu.edit_location')}
         onBack={(event) => {
           event.stopPropagation()
           history.push(`/locations/${locationId}`)
@@ -77,11 +74,12 @@ const AddLocation = ({ NavComponent, backUrl }) => {
   const history = useAppHistory()
   const formRef = useRef()
   const dispatch = useDispatch()
+  const { t } = useTranslation()
 
   return (
     <>
       <NavComponent
-        titleKey="layouts.page_title.adding_location"
+        title={t('menu.add_location')}
         onBack={(event) => {
           event.stopPropagation()
           if (formRef.current) {
@@ -98,11 +96,12 @@ const AddLocation = ({ NavComponent, backUrl }) => {
 const AddReview = ({ NavComponent }) => {
   const history = useAppHistory()
   const { locationId } = useParams()
+  const { t } = useTranslation()
 
   return (
     <>
       <NavComponent
-        titleKey="layouts.page_title.adding_review"
+        title={t('menu.add_review')}
         onBack={(event) => {
           event.stopPropagation()
           history.push(`/locations/${locationId}`)
@@ -116,11 +115,12 @@ const AddReview = ({ NavComponent }) => {
 const EditReview = ({ NavComponent }) => {
   const history = useAppHistory()
   const { review } = useSelector((state) => state.review)
+  const { t } = useTranslation()
 
   return (
     <>
       <NavComponent
-        titleKey="layouts.page_title.editing_review"
+        title={t('menu.edit_review')}
         onBack={(event) => {
           event.stopPropagation()
           history.push(`/locations/${review?.location_id}`)


### PR DESCRIPTION
Closes #672

I was able to also use these:

glossary.list>List
glossary.cancel>Cancel
view_location.date_edited>Updated {{date}}
side_menu.bicycle>Bicycle


A good AI prompt was to make a file with new translations, give it the mobile translations, and ask:
"We have some new translations and want to reuse existing keys. Add a third column to the new translations file, which indicates an existing key or keys that might be a good match, for those that are similar - as well as a forth column with the existing value in english"

I will probably do this again after migrating the locale out of the code.