### PR TITLE
Revise type search in location form

### DIFF
--- a/src/utils/localizedTypes.ts
+++ b/src/utils/localizedTypes.ts
@@ -101,7 +101,7 @@ const toMenuEntry = (
   }
 
   const commonNameLabel =
-    parentId === PENDING_ID ? `${commonName} (Pending Review)` : commonName
+    parentId === PENDING_ID ? `${commonName} (Pending review)` : commonName
 
   return {
     value: id,

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -119,13 +119,19 @@ const addTokenStart: Transform = (s) => `${TOKEN_START}${s}`
 
 const addTokenStartEnd: Transform = (s) => `${TOKEN_START}${s}${WORD_END}`
 
-const rightTrimWithWordEnd: Transform = (s) => s.replace(/\s+$/, WORD_END)
-
 const tokenize = pipe(convertLatinToAscii, removeIgnoredChars, (x) =>
   x.toLowerCase(),
 )
 
-export const tokenizeReference = (strings: string[]): string =>
-  strings.map(pipe(tokenize, addTokenStartEnd)).join('')
+export const tokenizeReference = (strings: string[]): string => {
+  const tokens = strings.map(pipe(tokenize, (x) => x.replace(/ $/g, '')))
+  // Add tokens with spaces to the list with spaces removed
+  tokens.forEach((x) => {
+    if (x.includes(' ')) {
+      tokens.push(x.replace(/ /g, ''))
+    }
+  })
+  return tokens.map(addTokenStartEnd).join('')
+}
 
-export const tokenizeQuery = pipe(tokenize, addTokenStart, rightTrimWithWordEnd)
+export const tokenizeQuery = pipe(tokenize, addTokenStart)

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -134,4 +134,8 @@ export const tokenizeReference = (strings: string[]): string => {
   return tokens.map(addTokenStartEnd).join('')
 }
 
-export const tokenizeQuery = pipe(tokenize, addTokenStart)
+export const tokenizeQuery = pipe(
+  tokenize,
+  (x) => x.replace(/([^ ]) ([^ ])/g, '$1$2'),
+  addTokenStart,
+)

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -106,9 +106,9 @@ const pipe =
   (x) =>
     fns.reduce((v, f) => f(v), x)
 
-const removeNonWordChars: Transform = (s) => s.replace(/[^\s\w]/g, '')
+const removeIgnoredChars: Transform = (s) => s.replace(/[\s-']/g, '')
 
-const convertToAscii: Transform = (s) =>
+const convertLatinToAscii: Transform = (s) =>
   s
     .split('')
     .map((c) => ASCII_MAP[c] || c)
@@ -120,10 +120,8 @@ const addTokenStartEnd: Transform = (s) => `${TOKEN_START}${s}${WORD_END}`
 
 const rightTrimWithWordEnd: Transform = (s) => s.replace(/\s+$/, WORD_END)
 
-const tokenize = pipe(
-  removeNonWordChars,
-  (x) => x.toLowerCase(),
-  convertToAscii,
+const tokenize = pipe(convertLatinToAscii, removeIgnoredChars, (x) =>
+  x.toLowerCase(),
 )
 
 export const tokenizeReference = (strings: string[]): string =>

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -97,7 +97,6 @@ for (const key in ASCII) {
 }
 
 const TOKEN_START = '^'
-const WORD_END = ' '
 
 type Transform = (_input: string) => string
 
@@ -116,15 +115,14 @@ const convertLatinToAscii: Transform = (s) =>
 
 const addTokenStart: Transform = (s) => `${TOKEN_START}${s}`
 
-const addTokenStartEnd: Transform = (s) => `${TOKEN_START}${s}${WORD_END}`
-
-const rightTrimWithWordEnd: Transform = (s) => s.replace(/\s+$/, WORD_END)
-
-const tokenize = pipe(convertLatinToAscii, removeIgnoredChars, (x) =>
-  x.toLowerCase(),
+const tokenize = pipe(
+  convertLatinToAscii,
+  removeIgnoredChars,
+  (x) => x.toLowerCase(),
+  addTokenStart,
 )
 
 export const tokenizeReference = (strings: string[]): string =>
-  strings.map(pipe(tokenize, addTokenStartEnd)).join('')
+  strings.map(tokenize).join('')
 
-export const tokenizeQuery = pipe(tokenize, addTokenStart, rightTrimWithWordEnd)
+export const tokenizeQuery = tokenize

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -106,8 +106,7 @@ const pipe =
   (x) =>
     fns.reduce((v, f) => f(v), x)
 
-const removeIgnoredChars: Transform = (s) =>
-  s.replace(/\s+/g, ' ').replace(/^ |[-']/g, '')
+const removeIgnoredChars: Transform = (s) => s.replace(/[\s-']/g, '')
 
 const convertLatinToAscii: Transform = (s) =>
   s
@@ -119,23 +118,13 @@ const addTokenStart: Transform = (s) => `${TOKEN_START}${s}`
 
 const addTokenStartEnd: Transform = (s) => `${TOKEN_START}${s}${WORD_END}`
 
+const rightTrimWithWordEnd: Transform = (s) => s.replace(/\s+$/, WORD_END)
+
 const tokenize = pipe(convertLatinToAscii, removeIgnoredChars, (x) =>
   x.toLowerCase(),
 )
 
-export const tokenizeReference = (strings: string[]): string => {
-  const tokens = strings.map(pipe(tokenize, (x) => x.replace(/ $/g, '')))
-  // Add tokens with spaces to the list with spaces removed
-  tokens.forEach((x) => {
-    if (x.includes(' ')) {
-      tokens.push(x.replace(/ /g, ''))
-    }
-  })
-  return tokens.map(addTokenStartEnd).join('')
-}
+export const tokenizeReference = (strings: string[]): string =>
+  strings.map(pipe(tokenize, addTokenStartEnd)).join('')
 
-export const tokenizeQuery = pipe(
-  tokenize,
-  (x) => x.replace(/([^ ]) ([^ ])/g, '$1$2'),
-  addTokenStart,
-)
+export const tokenizeQuery = pipe(tokenize, addTokenStart, rightTrimWithWordEnd)

--- a/src/utils/tokenize.ts
+++ b/src/utils/tokenize.ts
@@ -106,7 +106,8 @@ const pipe =
   (x) =>
     fns.reduce((v, f) => f(v), x)
 
-const removeIgnoredChars: Transform = (s) => s.replace(/[\s-']/g, '')
+const removeIgnoredChars: Transform = (s) =>
+  s.replace(/\s+/g, ' ').replace(/^ |[-']/g, '')
 
 const convertLatinToAscii: Transform = (s) =>
   s


### PR DESCRIPTION
After some experimenting and looking at common names in various languages, I opted to ignore whitespace. There are just so many cases of common synonyms differing by only a space, dash, or lack thereof.

Closes #684.
