### PR TITLE
Move desktop language select to header

### DIFF
--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -7,6 +7,7 @@ import { matchPath } from 'react-router'
 import { Link, NavLink, useLocation, useRouteMatch } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
+import { LanguageSelect } from '../../i18n'
 import { logout } from '../../redux/authSlice'
 import { pathWithCurrentView, withFromPage } from '../../utils/appUrl'
 import aboutRoutes from '../about/aboutRoutes'
@@ -30,7 +31,15 @@ const AuthLinksList = styled.ul`
   gap: 12px;
 `
 
-const TIGHT_LAYOUT_MAX_WIDTH = 940
+const TIGHT_LAYOUT_MAX_WIDTH = 1080
+const TIGHT_LAYOUT_MAX_WIDTH_USER = 980
+
+function layoutIstight(user) {
+  return (
+    (user && window.innerWidth <= TIGHT_LAYOUT_MAX_WIDTH_USER) ||
+    (!user && window.innerWidth <= TIGHT_LAYOUT_MAX_WIDTH)
+  )
+}
 
 const StyledHeader = styled.header`
   height: 56px;
@@ -47,8 +56,7 @@ const StyledHeader = styled.header`
   }
 
   .hamburger {
-    display: ${({ user }) =>
-      !user && window.innerWidth <= TIGHT_LAYOUT_MAX_WIDTH ? 'flex' : 'none'};
+    display: ${({ user }) => (layoutIstight(user) ? 'flex' : 'none')};
     margin-right: 1rem;
     cursor: pointer;
     color: ${({ theme }) => theme.secondaryText};
@@ -63,8 +71,7 @@ const StyledHeader = styled.header`
     flex: 1;
 
     .main-menu {
-      display: ${({ user }) =>
-        user || window.innerWidth > TIGHT_LAYOUT_MAX_WIDTH ? 'block' : 'none'};
+      display: ${({ user }) => (layoutIstight(user) ? 'none' : 'block')};
 
       &.mobile-visible {
         display: block;
@@ -342,6 +349,11 @@ const MainMenu = ({ className }) => {
               {t('layouts.application.menu.in_the_press')}
             </NavLink>
           </StyledDropdown>
+        </NavLi>
+        <NavLi>
+          <div style={{ width: '10em', margin: 'auto 0' }}>
+            <LanguageSelect></LanguageSelect>
+          </div>
         </NavLi>
       </NavList>
     </div>

--- a/src/components/settings/SettingsPage.js
+++ b/src/components/settings/SettingsPage.js
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
 
-import { LANGUAGE_CACHE_KEY, LANGUAGE_OPTIONS } from '../../i18n'
+import { LanguageSelect } from '../../i18n'
 import { updateSettings } from '../../redux/settingsSlice'
 import { useAppHistory } from '../../utils/useAppHistory'
 import Checkbox from '../ui/Checkbox'
@@ -137,7 +137,7 @@ const SettingsPage = ({ desktop }) => {
 
   const history = useAppHistory()
 
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
 
   const DISTANCE_UNIT_OPTIONS = [
     { value: 'metric', label: t('pages.settings.units.metric') },
@@ -300,47 +300,35 @@ const SettingsPage = ({ desktop }) => {
         <Attribution>{Attributions[settings.mapType]}</Attribution>
       )}
 
-      <h3>{t('pages.settings.regional')}</h3>
-
-      <LabeledRow
-        label={
-          <label htmlFor="languagePreference">
-            {t('pages.settings.language')}
-          </label>
-        }
-        right={
-          <Select
-            options={LANGUAGE_OPTIONS}
-            value={LANGUAGE_OPTIONS.find(
-              (option) => option.value === i18n.language,
-            )}
-            onChange={(option) => {
-              i18n.changeLanguage(option.value, () => {
-                localStorage.setItem(LANGUAGE_CACHE_KEY, option.value)
-              })
-            }}
-            isSearchable={false}
-            menuPlacement="top"
-          />
-        }
-      />
       {!desktop && (
-        <LabeledRow
-          label={
-            <label htmlFor="distanceUnit">
-              {t('pages.settings.units.units')}
-            </label>
-          }
-          right={
-            <Select
-              options={DISTANCE_UNIT_OPTIONS}
-              onChange={updateUnitsSetting}
-              value={DISTANCE_UNIT_OPTIONS.find(
-                (option) => option.value === settings.distanceUnit,
-              )}
-            />
-          }
-        />
+        <>
+          <h3>{t('pages.settings.regional')}</h3>
+
+          <LabeledRow
+            label={
+              <label htmlFor="languagePreference">
+                {t('pages.settings.language')}
+              </label>
+            }
+            right={<LanguageSelect></LanguageSelect>}
+          />
+          <LabeledRow
+            label={
+              <label htmlFor="distanceUnit">
+                {t('pages.settings.units.units')}
+              </label>
+            }
+            right={
+              <Select
+                options={DISTANCE_UNIT_OPTIONS}
+                onChange={updateUnitsSetting}
+                value={DISTANCE_UNIT_OPTIONS.find(
+                  (option) => option.value === settings.distanceUnit,
+                )}
+              />
+            }
+          />
+        </>
       )}
 
       {!desktop && (

--- a/src/components/ui/Select.js
+++ b/src/components/ui/Select.js
@@ -26,7 +26,6 @@ const SelectParent = styled.div`
   .select__control {
     border: 1px solid ${validatedColor()};
     border-radius: 0.375em;
-    padding: 3px 10px;
   }
 
   .select__input {
@@ -36,6 +35,10 @@ const SelectParent = styled.div`
 
   .select__placeholder {
     color: ${({ theme }) => theme.text};
+  }
+
+  .select__single-value {
+    color: ${({ theme }) => theme.secondaryText};
   }
 
   .select__multi-value {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,7 +16,6 @@ const LanguageSelect = () => {
   // Style the select component with width: 10em
   return (
     <Select
-      style={{ width: '10em', margin: 'auto 0' }}
       options={LANGUAGE_OPTIONS}
       value={LANGUAGE_OPTIONS.find((option) => option.value === i18n.language)}
       onChange={(option) => {

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,13 +1,34 @@
 import i18n from 'i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import Backend from 'i18next-http-backend'
-import { initReactI18next } from 'react-i18next'
+import { initReactI18next, useTranslation } from 'react-i18next'
+
+import { Select } from './components/ui/Select'
 
 export const LANGUAGE_CACHE_KEY = 'language'
 export const LANGUAGE_OPTIONS = [
   { value: 'en', label: 'English' },
   { value: 'fr', label: 'Français' },
 ]
+
+const LanguageSelect = () => {
+  const { i18n } = useTranslation()
+  // Style the select component with width: 10em
+  return (
+    <Select
+      style={{ width: '10em', margin: 'auto 0' }}
+      options={LANGUAGE_OPTIONS}
+      value={LANGUAGE_OPTIONS.find((option) => option.value === i18n.language)}
+      onChange={(option) => {
+        i18n.changeLanguage(option.value, () => {
+          localStorage.setItem(LANGUAGE_CACHE_KEY, option.value)
+        })
+      }}
+      isSearchable={false}
+      menuPlacement="top"
+    />
+  )
+}
 
 i18n
   .use(initReactI18next)
@@ -32,4 +53,5 @@ i18n
     },
   })
 
+export { LanguageSelect }
 export default i18n


### PR DESCRIPTION
* I placed the select at the right-end of the main menu, so that it is accessed via hamburger menu in tight layout.
* I have no idea why it was necessary to wrap `LanguageSelect` in a styled div rather than style `LanguageSelect` directly.
* The additional element in the header meant increasing the max width of the tight desktop layout.

Closes #683.