### PR TITLE
Reconnect initial view if there's location but no view

### DIFF
--- a/src/components/connect/ConnectLocation.js
+++ b/src/components/connect/ConnectLocation.js
@@ -70,6 +70,15 @@ const ConnectLocation = ({
   }, [dispatch, locationId]) //eslint-disable-line
 
   useEffect(() => {
+    if (location && !initialView) {
+      const { view } = parseCurrentUrl()
+      if (view) {
+        dispatch(setInitialView(view))
+      }
+    }
+  }, [!!location, !!initialView]) //eslint-disable-line
+
+  useEffect(() => {
     dispatch(setIsBeingEditedAndResetPosition(isBeingEdited))
   }, [dispatch, isBeingEdited])
 

--- a/src/components/connect/ConnectReview.js
+++ b/src/components/connect/ConnectReview.js
@@ -4,16 +4,18 @@ import { useDispatch, useSelector } from 'react-redux'
 import { fetchLocationData } from '../../redux/locationSlice'
 import { setInitialView } from '../../redux/mapSlice'
 import { fetchReviewData } from '../../redux/reviewSlice'
+import { parseCurrentUrl } from '../../utils/appUrl'
 import { useIsDesktop } from '../../utils/useBreakpoint'
 
 const ConnectReview = ({ reviewId }) => {
   const dispatch = useDispatch()
-  const { googleMap } = useSelector((state) => state.map)
+  const { initialView } = useSelector((state) => state.map)
   const isDesktop = useIsDesktop()
+  const { location } = useSelector((state) => state.location)
 
   useEffect(() => {
     dispatch(fetchReviewData(reviewId)).then((action) => {
-      if (action.payload && !googleMap && isDesktop) {
+      if (action.payload && !initialView && isDesktop) {
         const locationId = action.payload.location_id
         dispatch(fetchLocationData({ locationId, isBeingEdited: false })).then(
           (locationAction) => {
@@ -33,6 +35,15 @@ const ConnectReview = ({ reviewId }) => {
       }
     })
   }, [dispatch, reviewId]) //eslint-disable-line
+
+  useEffect(() => {
+    if (location && !initialView && isDesktop) {
+      const { view } = parseCurrentUrl()
+      if (view) {
+        dispatch(setInitialView(view))
+      }
+    }
+  }, [!!location, !!initialView]) //eslint-disable-line
 
   return null
 }


### PR DESCRIPTION
Can happen if we navigate away from the map on desktop e.g. from location to users page and arrow back, or edit review and browser back.

Closes #702 

Thanks Ethan for reporting!