### PR TITLE
If on the map is unchecked, all selectable parents should duplicate as their own leaves

### DIFF
--- a/src/utils/buildSelectTree.ts
+++ b/src/utils/buildSelectTree.ts
@@ -119,7 +119,12 @@ class SelectTreeBuilder {
       : type.scientificName
 
     const ownCount = this.getCount(type.id)
-    if (children.length && ownCount > 0 && matchesSearch) {
+    if (
+      children.length &&
+      (ownCount > 0 ||
+        (!this.showOnlyOnMap && this.typesAccess.isSelectable(type.id))) &&
+      matchesSearch
+    ) {
       const childNode: RenderTreeNode = {
         ...node,
         id: -type.id, // Use negative ID to ensure uniqueness

--- a/src/utils/localizedTypes.ts
+++ b/src/utils/localizedTypes.ts
@@ -137,6 +137,10 @@ export class TypesAccess {
     return this.localizedTypes.filter((t) => t.id !== PENDING_ID)
   }
 
+  isSelectable(id: Id): boolean {
+    return id !== PENDING_ID
+  }
+
   getType(id: Id): LocalizedType {
     return this.localizedTypes[this.idIndex[id]]
   }


### PR DESCRIPTION
Closes #730

Should help with #655, although it's not quite a fix - the suggestion there is that if user selects e.g. apples, and moves the map, any apple cultivars that weren't previously visible should still be selected.