### PR TITLE
Close the menu on select in type select, because it's hard to dismiss on mobile

### DIFF
--- a/src/components/form/TypesSelect.js
+++ b/src/components/form/TypesSelect.js
@@ -54,7 +54,7 @@ const TypesSelect = () => {
         label={t('glossary.type.other')}
         options={typeOptions}
         isMulti
-        closeMenuOnSelect={false}
+        closeMenuOnSelect
         blurInputOnSelect={false}
         formatOptionLabel={(option) =>
           option.__isNew__ ? (


### PR DESCRIPTION
Closes #759 . Thanks to Ben from REED Center for reporting!