### PR TITLE
Fix how we load map

### DIFF
--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -241,12 +241,20 @@ const MapPage = ({ isDesktop }) => {
 
   const { typesAccess } = useSelector((state) => state.type)
 
-  const ready = !typesAccess.isEmpty && !!googleMap
   useEffect(() => {
+    const ready =
+      !typesAccess.isEmpty && !!googleMap && !!initialView && !!dispatch
     if (ready) {
+      /*
+       * Install the handler as we now have all variables
+       */
+      handleViewChangeRef.current = throttle(
+        makeHandleViewChange(dispatch, googleMap, history),
+        1000,
+      )
       handleViewChangeRef.current(false)
     }
-  }, [ready])
+  }, [!typesAccess.isEmpty, !!googleMap, !!initialView, !!dispatch]) //eslint-disable-line
 
   const allLocations =
     clusters.length !== 0
@@ -268,13 +276,6 @@ const MapPage = ({ isDesktop }) => {
   }, [position, isDesktop])
 
   const apiIsLoaded = (map, maps) => {
-    /*
-     * Install the handler as we now have all variables
-     */
-    handleViewChangeRef.current = throttle(
-      makeHandleViewChange(dispatch, map, history),
-      1000,
-    )
     /*
      * Something breaks when storing maps in redux so pass a reference to it
      */

--- a/src/redux/mapSlice.js
+++ b/src/redux/mapSlice.js
@@ -66,8 +66,10 @@ export const mapSlice = createSlice({
       state.googleMap = action.payload.googleMap
       state.getGoogleMaps = action.payload.getGoogleMaps
     },
-    clearInitialView: (state) => {
+    disconnectMap: (state) => {
       state.initialView = null
+      state.googleMap = null
+      state.getGoogleMaps = null
     },
     setInitialView: (state, action) => {
       state.initialView = action.payload
@@ -140,6 +142,6 @@ export const mapSlice = createSlice({
   },
 })
 
-export const { clearInitialView, setGoogle, setInitialView } = mapSlice.actions
+export const { disconnectMap, setGoogle, setInitialView } = mapSlice.actions
 
 export default mapSlice.reducer

--- a/src/redux/viewportSlice.js
+++ b/src/redux/viewportSlice.js
@@ -9,8 +9,15 @@ export const viewportSlice = createSlice({
   },
   reducers: {
     updateLastMapView: (state, action) => {
-      if (action.payload.width > 0 && action.payload.height > 0) {
-        state.lastMapView = action.payload
+      /*
+       * height and width are set to zero when coming back from list or activity page
+       * (if the API was previously loaded but map went off screen)
+       */
+      // Hold on to the viewport dimensions so we can use it
+      state.lastMapView = {
+        ...action.payload,
+        height: action.payload.height || state.lastMapView?.height,
+        width: action.payload.width || state.lastMapView?.width,
       }
     },
   },


### PR DESCRIPTION
On desktop, we could be coming back to the map component rendering for the first time but the API already loaded - spotted on activity page but maybe also /about will work?

Change the effects in MapPage to install the handler each time the map becomes ready, not just on API load

This then needs a change elsewhere but done

Closes #760