### PR TITLE
Validate after position change not on mount

### DIFF
--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -300,7 +300,6 @@ export const LocationForm = ({ editingId, innerRef }) => {
       <Formik
         validate={validateLocation}
         initialValues={mergedInitialValues}
-        validateOnMount
         onSubmit={isLoggedIn ? handleSubmit : onPresubmit}
         innerRef={innerRef}
       >

--- a/src/utils/form.js
+++ b/src/utils/form.js
@@ -84,6 +84,9 @@ export const validateLocation = ({ review, ...location }) => {
   if (location.types.length === 0) {
     errors.types = true
   }
+  if (!location.position) {
+    errors.position = true
+  }
 
   if (!isEmptyReview(review)) {
     Object.assign(errors, validateReview(review))


### PR DESCRIPTION
Closes #782 

Thanks Ethan for spotting the bug. I narrowed it down to formik's validation rerunning with initial values - not  formikProps.values - after position changes. The initial value for types is [], so there's an error and submit is greyed out.

 It doesn't seem like validateOnMount=true should cause formik to validate after props change and I'm not sure what the purpose of the setting was, but removing it seems to work. 