### PR TITLE
Fix signup flow

### DIFF
--- a/src/components/auth/SignupPage.js
+++ b/src/components/auth/SignupPage.js
@@ -102,6 +102,7 @@ const SignupPage = () => {
                 name="password_confirm"
                 label={t('users.password_confirmation')}
                 required
+                invalidWhenUntouched
               />
               {errors.password_confirm && (
                 <ErrorMessage>


### PR DESCRIPTION
Closes: https://github.com/falling-fruit/falling-fruit-web/issues/862

The purpose of this PR is to fix the broken signup flow. Fixes by:
- Preventing duplicate API calls in ConfirmationPage due to React StrictMode
- Better handling of edge cases where users try to confirm an already-confirmed account
- Enhanced form validation for password confirmation that shows validation feedback immediately

I've implemented my best guess of the solution based on the issue description, however I don't have a great way of testing the signup flow.

Would love to learn how!