### PR TITLE
Fix checkbox squishing in LabeledRow on small screens

### DIFF
--- a/src/components/ui/LabeledRow.js
+++ b/src/components/ui/LabeledRow.js
@@ -18,6 +18,7 @@ const StyledLabeledInput = styled.div`
       font-weight: bold;
       color: ${({ theme }) => theme.secondaryText};
       cursor: pointer;
+      flex: 1;
     }
   }
 `


### PR DESCRIPTION
Closes #926 

I followed @wbazant hint and added a flex attribute to the label of LabeledRow component. 
I checked with Chrome and Firefox and the checkbox did not get squished up.

<details>
<summary>Before / After</summary>

**Before**
<img width="315" height="470" alt="Before: checkbox squished on small viewport" src="https://github.com/user-attachments/assets/a32be496-d447-472c-a980-4fb145277fa9" />

**After**
<img width="317" height="461" alt="After: checkbox stable on small viewport" src="https://github.com/user-attachments/assets/868729c9-6e38-4308-a097-63a02014b778" />
</details>
