### PR TITLE
Document REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID in setup instructions

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -38,6 +38,8 @@
 
   - `REACT_APP_GOOGLE_MAPS_API_KEY`: Your own API key for [Google Maps Platform](https://developers.google.com/maps/documentation/javascript/get-api-key).
 
+  - `REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID`: Tracking ID for Google Analytics. Optional.
+
 - Start the application.
 
   ```sh


### PR DESCRIPTION
As a new contributor following the setup steps, I noticed that `example.env`
includes `REACT_APP_GOOGLE_ANALYTICS_TRACKING_ID`, which was not mentioned in the README.

This PR adds a short note about the variable to keep the setup instructions
consistent.