### PR TITLE
Add password visibility toggle to input field

### DIFF
--- a/src/components/account/ChangeEmailPage.js
+++ b/src/components/account/ChangeEmailPage.js
@@ -13,7 +13,7 @@ import {
   FormButtonWrapper,
   FormInputWrapper,
 } from '../auth/AuthWrappers'
-import { Input } from '../form/FormikWrappers'
+import { Input, PasswordInput } from '../form/FormikWrappers'
 import { BackButton } from '../ui/ActionButtons'
 import Button from '../ui/Button'
 import LoadingIndicator from '../ui/LoadingIndicator'
@@ -108,9 +108,8 @@ const ChangeEmailPage = () => {
                     required
                   />
                   {errors.email && <ErrorMessage>{errors.email}</ErrorMessage>}
-                  <Input
+                  <PasswordInput
                     name="password"
-                    type="password"
                     label={t('glossary.password')}
                     autoComplete="current-password"
                     required

--- a/src/components/account/ChangePasswordPage.js
+++ b/src/components/account/ChangePasswordPage.js
@@ -13,7 +13,7 @@ import {
   FormButtonWrapper,
   FormInputWrapper,
 } from '../auth/AuthWrappers'
-import { Input } from '../form/FormikWrappers'
+import { PasswordInput } from '../form/FormikWrappers'
 import { BackButton } from '../ui/ActionButtons'
 import Button from '../ui/Button'
 import LoadingIndicator from '../ui/LoadingIndicator'
@@ -79,16 +79,14 @@ const ChangePasswordPage = () => {
             {({ errors, dirty, isValid, isSubmitting }) => (
               <Form>
                 <FormInputWrapper>
-                  <Input
+                  <PasswordInput
                     invalidWhenUntouched
                     name="password"
-                    type="password"
                     label={t('users.current_password')}
                     required
                   />
-                  <Input
+                  <PasswordInput
                     name="new_password"
-                    type="password"
                     label={t('users.new_password')}
                     autoComplete="new-password"
                     required
@@ -104,9 +102,8 @@ const ChangePasswordPage = () => {
                     </ErrorMessage>
                   )}
 
-                  <Input
+                  <PasswordInput
                     name="new_password_confirm"
-                    type="password"
                     label={t('users.new_password_confirmation')}
                     autoComplete="new-password"
                     required

--- a/src/components/auth/LoginPage.js
+++ b/src/components/auth/LoginPage.js
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router-dom'
 import * as Yup from 'yup'
 
 import { login } from '../../redux/authSlice'
-import { Checkbox, Input } from '../form/FormikWrappers'
+import { Checkbox, Input, PasswordInput } from '../form/FormikWrappers'
 import Button from '../ui/Button'
 import LabeledRow from '../ui/LabeledRow'
 import { AuthPage } from '../ui/PageTemplate'
@@ -52,11 +52,7 @@ const LoginPage = () => {
                 label={t('glossary.email')}
                 autoComplete="off"
               />
-              <Input
-                name="password"
-                type="password"
-                label={t('glossary.password')}
-              />
+              <PasswordInput name="password" label={t('glossary.password')} />
             </FormInputWrapper>
 
             <FormCheckboxWrapper>

--- a/src/components/auth/PasswordSetPage.js
+++ b/src/components/auth/PasswordSetPage.js
@@ -6,7 +6,7 @@ import * as Yup from 'yup'
 
 import { resetPassword } from '../../utils/api'
 import { useAppHistory } from '../../utils/useAppHistory'
-import { Input } from '../form/FormikWrappers'
+import { PasswordInput } from '../form/FormikWrappers'
 import Button from '../ui/Button'
 import { AuthPage } from '../ui/PageTemplate'
 import AuthLinks from './AuthLinks'
@@ -70,19 +70,14 @@ const PasswordSetPage = () => {
         {({ errors, dirty, isValid, isSubmitting, values }) => (
           <Form>
             <FormInputWrapper>
-              <Input
-                type="password"
-                name="password"
-                label={t('users.new_password')}
-              />
+              <PasswordInput name="password" label={t('users.new_password')} />
               {errors.password && (
                 <ErrorMessage>
                   {t(errors.password.key, errors.password.options)}
                 </ErrorMessage>
               )}
 
-              <Input
-                type="password"
+              <PasswordInput
                 name="password_confirm"
                 label={t('users.new_password_confirmation')}
                 invalidWhenUntouched={values.password !== ''}

--- a/src/components/auth/SignupPage.js
+++ b/src/components/auth/SignupPage.js
@@ -6,7 +6,13 @@ import * as Yup from 'yup'
 
 import { addUser } from '../../utils/api'
 import { useAppHistory } from '../../utils/useAppHistory'
-import { Checkbox, Input, Recaptcha, Textarea } from '../form/FormikWrappers'
+import {
+  Checkbox,
+  Input,
+  PasswordInput,
+  Recaptcha,
+  Textarea,
+} from '../form/FormikWrappers'
 import Button from '../ui/Button'
 import LabeledRow from '../ui/LabeledRow'
 import { AuthPage } from '../ui/PageTemplate'
@@ -76,8 +82,7 @@ const SignupPage = () => {
                 autoComplete="off"
               />
 
-              <Input
-                type="password"
+              <PasswordInput
                 name="password"
                 label={t('glossary.password')}
                 required
@@ -88,8 +93,7 @@ const SignupPage = () => {
                 </ErrorMessage>
               )}
 
-              <Input
-                type="password"
+              <PasswordInput
                 name="password_confirm"
                 label={t('users.password_confirmation')}
                 required

--- a/src/components/form/FormikWrappers.js
+++ b/src/components/form/FormikWrappers.js
@@ -7,6 +7,7 @@ import { useIsMobile } from '../../utils/useBreakpoint'
 import { PhotoUploader } from '../photo/PhotoUploader'
 import Checkbox from '../ui/Checkbox'
 import Input from '../ui/Input'
+import PasswordInput from '../ui/PasswordInput'
 import RatingInput from '../ui/RatingInput'
 import { CreatableSelect, Select } from '../ui/Select'
 import { Slider } from '../ui/Slider'
@@ -44,6 +45,7 @@ const DateInput = ({ $invalid: _$invalid, name, ...props }) => {
 }
 
 const FormikInput = withLabeledField(Input)
+const FormikPasswordInput = withLabeledField(PasswordInput)
 const FormikTextarea = withLabeledField(Textarea)
 const FormikDateInput = withLabeledField(DateInput)
 const FormikSlider = withLabeledField(Slider, undefined, true)
@@ -94,6 +96,7 @@ export {
   FormikCreatableSelect as CreatableSelect,
   FormikDateInput as DateInput,
   FormikInput as Input,
+  FormikPasswordInput as PasswordInput,
   FormikPhotoUploader as PhotoUploader,
   FormikRatingInput as RatingInput,
   FormikRecaptcha as Recaptcha,

--- a/src/components/ui/PasswordInput.js
+++ b/src/components/ui/PasswordInput.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react'
+
+import Input from './Input'
+import ResetButton from './ResetButton'
+
+function EyeIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z" />
+      <circle cx="12" cy="12" r="3" />
+    </svg>
+  )
+}
+
+function EyeOffIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+    >
+      <path d="M17.94 17.94A10.94 10.94 0 0 1 12 19c-7 0-11-7-11-7a21.77 21.77 0 0 1 5.06-5.94" />
+      <path d="M1 1l22 22" />
+      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 7 11 7a21.82 21.82 0 0 1-3.87 5.68" />
+      <path d="M14.12 14.12A3 3 0 0 1 9.88 9.88" />
+    </svg>
+  )
+}
+
+export default function PasswordInput(props) {
+  const [showPassword, setShowPassword] = useState(false)
+
+  return (
+    <Input
+      {...props}
+      type={showPassword ? 'text' : 'password'}
+      append={
+        <ResetButton
+          type="button"
+          aria-label={showPassword ? 'Hide password' : 'Show password'}
+          onClick={() => setShowPassword((v) => !v)}
+        >
+          <span className="password-eye-icon">
+            {showPassword ? <EyeOffIcon /> : <EyeIcon />}
+          </span>
+        </ResetButton>
+      }
+    />
+  )
+}

--- a/src/components/ui/ResetButton.js
+++ b/src/components/ui/ResetButton.js
@@ -1,14 +1,32 @@
 import styled from 'styled-components/macro'
 
 const ResetButton = styled.button`
-  background: none;
-  border: none;
-  padding: 0;
-  font-family: inherit;
+  // background: none;
+  // border: none;
+  // padding: 4px;
+  // font-family: inherit;
+  // color: #666;
   // outline: inherit;
   // TODO: should outline be removed? a11y
 
   ${({ disabled }) => !disabled && 'cursor: pointer;'}
+
+  background: none;
+  border: none;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  .password-eye-icon {
+    display: inline-flex;
+    transform: scale(0.65); /* 👈 YAHI SIZE CONTROL */
+    transform-origin: center;
+  }
+
+  &:not([disabled]) {
+    cursor: pointer;
+  }
 `
 
 export default ResetButton


### PR DESCRIPTION
This PR adds a password visibility toggle (eye icon) to password input fields, allowing users to easily show or hide their password while typing.

This improves usability across authentication and account pages by reducing password entry mistakes and making form interactions more user-friendly.

The change is scoped only to password fields and does not affect other input behavior.

Closes #946 