### PR TITLE
Vary label style by map type

### DIFF
--- a/src/components/map/LocationMarkers.js
+++ b/src/components/map/LocationMarkers.js
@@ -93,10 +93,9 @@ const getLabelStyleConfig = (mapType) => {
 
 const setLabelTextStyle = (div, mapType) => {
   const config = getLabelStyleConfig(mapType)
-  div.style.fontWeight = config.fontWeight
-  div.style.color = config.color
-  div.style.textShadow = config.textShadow
-  div.style.backgroundColor = config.backgroundColor
+  Object.keys(config).forEach((key) => {
+    div.style[key] = config[key]
+  })
 }
 
 const createBaseLabelDiv = () => {


### PR DESCRIPTION
Closes #961 

I noticed Google Maps themselves style the labels differently for different maps, so we can use the white text with dark outline on satellite view. Then toner lite has dark and bold text, and OSM is more colorful than Map/Terrain so the background seems to help there.