### PR TITLE
Fix: Remove unwanted underline from Sign In button on desktop

### DIFF
--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -106,10 +106,7 @@ const NavLi = styled.li`
   &.signin,
   &.signup {
     min-width: auto;
-
-    a.active::before {
-      display: none;
-    }
+    /* Removed the 'display: none' hack from here */
   }
 
   a,
@@ -127,16 +124,21 @@ const NavLi = styled.li`
     &.active {
       background-color: ${({ theme }) => theme.navBackground};
       color: ${({ theme }) => theme.orange};
+      /* Removed the universal ::before underline from here */
+    }
+  }
 
-      ::before {
-        content: '';
-        width: 100%;
-        position: absolute;
-        background-color: ${({ theme }) => theme.orange};
-        height: 3px;
-        inset-block-end: 0;
-        inset-inline-start: 0;
-      }
+  /* NEW: Only apply the underline if this is NOT a signin or signup button */
+  &:not(.signin):not(.signup) {
+    a.active::before,
+    .content button.active::before {
+      content: '';
+      width: 100%;
+      position: absolute;
+      background-color: ${({ theme }) => theme.orange};
+      height: 3px;
+      inset-block-end: 0;
+      inset-inline-start: 0;
     }
   }
 


### PR DESCRIPTION
Fixes #968 

## Description
This PR fixes the issue where an unwanted bottom border (underline) appeared on the "Sign in" button on desktop views.

## The Issue
The issue was caused by the `NavLi` styled component in `src/components/desktop/Header.js`. It applies a `::before` pseudo-element (an orange underline) to any active link to indicate the current page.

Since the "Sign in" button is wrapped in a `NavLink`, it was inheriting this underline style when the user was on the login page, resulting in a "double border" look.

## The Fix
I added a specific rule to hide this pseudo-element for the authentication buttons. This ensures the buttons keep their box styling without the navigation underline.

**File Changed:** `src/components/desktop/Header.js`

```javascript
&.signin,
&.signup {
  /* ... existing styles ... */

  /* Fix: Hide the active link underline for buttons */
  a.active::before {
    display: none;
  }
}