### PR TITLE
Fix: Remove unwanted underline from Sign In button on desktop

### DIFF
--- a/src/components/desktop/Header.js
+++ b/src/components/desktop/Header.js
@@ -91,7 +91,6 @@ const StyledHeader = styled.header`
 `
 
 const MenuItem = styled(NavLink)`
-  text-decoration: none;
   color: ${({ theme }) => theme.secondaryText};
   text-align: center;
   display: flex;
@@ -146,11 +145,6 @@ const NavLi = styled.li`
     flex: 1;
     font-weight: inherit;
     font-size: inherit;
-
-    &.active {
-      background-color: ${({ theme }) => theme.navBackground};
-      color: ${({ theme }) => theme.orange};
-    }
   }
 
   &.active {


### PR DESCRIPTION
## Description
Fixes the unwanted orange underline appearing on the Sign In button on desktop view.

## Changes
- Added specific styles for `.signin` and `.signup` NavLink elements
- Hides the `::before` pseudo-element that creates the underline
- Prevents underline from showing on both hover and active states

## Fixes
Closes #968

## Screenshots
Before: (The issue screenshot from #968)
After: Sign In button now appears without the bottom border
<img width="1900" height="960" alt="image" src="https://github.com/user-attachments/assets/f9f7b279-7560-4ca6-9854-8758cd292e9f" />
## Testing
Tested on desktop view - Sign In button no longer shows orange underline.

