### PR TITLE
Fix ConnectPath

### DIFF
--- a/src/components/connect/ConnectPath.js
+++ b/src/components/connect/ConnectPath.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
@@ -9,34 +9,9 @@ const ConnectPath = () => {
   const { pathname } = useLocation()
   const hasInitialView = !!initialView
   const view = viewFromCurrentUrl()
-  const [isMapIdle, setIsMapIdle] = useState(true)
 
   useEffect(() => {
-    if (!googleMap) {
-      return
-    }
-
-    const idleListener = googleMap.addListener('idle', () => {
-      setIsMapIdle(true)
-    })
-
-    const dragStartListener = googleMap.addListener('dragstart', () => {
-      setIsMapIdle(false)
-    })
-
-    const zoomChangedListener = googleMap.addListener('zoom_changed', () => {
-      setIsMapIdle(false)
-    })
-
-    return () => {
-      idleListener.remove()
-      dragStartListener.remove()
-      zoomChangedListener.remove()
-    }
-  }, [googleMap])
-
-  useEffect(() => {
-    if (hasInitialView && googleMap && view && isMapIdle) {
+    if (hasInitialView && googleMap && view) {
       const currentCenter = googleMap.getCenter()
       const currentZoom = googleMap.getZoom()
 
@@ -44,7 +19,7 @@ const ConnectPath = () => {
         Math.abs(currentCenter.lat(), view.center.lat) > 1e-7 ||
         Math.abs(currentCenter.lng(), view.center.lng) > 1e-7
       ) {
-        googleMap.setCenter(view.center)
+        googleMap.panTo(view.center)
       }
 
       if (currentZoom !== view.zoom) {

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -69,7 +69,7 @@ const connectRoutes = [
   /*
    * ConnectPath
    * why:
-   * - if something else changed the URL, e.g. the back button, the map needs to get back in sync
+   * - if something else changed the URL, e.g. the back button, a share link on mobile being opened, or history.pushAndChangeView being called, the map needs to get back in sync
    *
    * action:
    * - if the map is present but not in sync with the URL, navigate to the URL's view


### PR DESCRIPTION
Remove stuff about not panning the map when not idle, this was an attempt to solve a 'jank' caused by a sequence of moving the map, issuing a history.push, then ConnectPath checking the path and sometimes moving the URL. This was solved by syncing the browser URL after map change outside the React Router. 


Also pan instead of setting center: nicer when e.g. at a postcode g429dn and then searching for g429lf, which just glides the map. 

Closes #978