### PR TITLE
Fail when captcha fails

### DIFF
--- a/public/locales/ar.json
+++ b/public/locales/ar.json
@@ -65,6 +65,7 @@
       "not_supported": "تحديد الموقع الجغرافي غير مدعوم"
     },
     "language_changed_refresh_to_reload_map": "تم تغيير اللغة، يرجى تحديث الصفحة لإعادة تحميل الخريطة",
+    "recaptcha_failed": "فشل التحقق من ReCAPTCHA",
     "results_unavailable": "النتائج غير متاحة",
     "unknown_error": "خطأ غير معروف"
   },

--- a/public/locales/de.json
+++ b/public/locales/de.json
@@ -65,6 +65,7 @@
       "not_supported": "Geolokalisierung wird nicht unterstützt"
     },
     "language_changed_refresh_to_reload_map": "Sprache geändert. Bitte lade die Seite neu, um die Karte zu aktualisieren",
+    "recaptcha_failed": "ReCAPTCHA fehlgeschlagen",
     "results_unavailable": "Ergebnisse nicht verfügbar",
     "unknown_error": "Unbekannter Fehler"
   },

--- a/public/locales/el.json
+++ b/public/locales/el.json
@@ -65,6 +65,7 @@
       "not_supported": "Ο εντοπισμός τοποθεσίας δεν υποστηρίζεται"
     },
     "language_changed_refresh_to_reload_map": "Η γλώσσα άλλαξε. Ανανεώστε τη σελίδα για να επαναφορτωθεί ο χάρτης",
+    "recaptcha_failed": "Αποτυχία ReCAPTCHA",
     "results_unavailable": "Τα αποτελέσματα δεν είναι διαθέσιμα",
     "unknown_error": "Άγνωστο σφάλμα"
   },

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -66,6 +66,7 @@
     },
     "language_changed_refresh_to_reload_map": "Language changed. Refresh page to reload map",
     "unknown_error": "Unknown error",
+    "recaptcha_failed": "ReCAPTCHA failed",
     "results_unavailable": "Results unavailable"
   },
   "filter": {

--- a/public/locales/es.json
+++ b/public/locales/es.json
@@ -65,6 +65,7 @@
       "not_supported": "Geolocalización no compatible"
     },
     "language_changed_refresh_to_reload_map": "El idioma ha cambiado. Actualiza la página para recargar el mapa",
+    "recaptcha_failed": "ReCAPTCHA falló",
     "results_unavailable": "Resultados no disponibles",
     "unknown_error": "Error desconocido"
   },

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -65,6 +65,7 @@
       "not_supported": "Géolocalisation non prise en charge"
     },
     "language_changed_refresh_to_reload_map": "La langue a été modifiée. Actualise la page pour recharger la carte.",
+    "recaptcha_failed": "Échec du ReCAPTCHA",
     "results_unavailable": "Résultats indisponibles",
     "unknown_error": "Erreur inconnue"
   },

--- a/public/locales/he.json
+++ b/public/locales/he.json
@@ -65,6 +65,7 @@
       "not_supported": "איתור מיקום אינו נתמך"
     },
     "language_changed_refresh_to_reload_map": "השפה השתנתה, יש לרענן את הדף כדי לטעון מחדש את המפה",
+    "recaptcha_failed": "ReCAPTCHA נכשל",
     "results_unavailable": "תוצאות לא זמינות",
     "unknown_error": "שגיאה לא ידועה"
   },

--- a/public/locales/it.json
+++ b/public/locales/it.json
@@ -65,6 +65,7 @@
       "not_supported": "Geolocalizzazione non supportata"
     },
     "language_changed_refresh_to_reload_map": "Lingua modificata, aggiorna la pagina per ricaricare la mappa",
+    "recaptcha_failed": "ReCAPTCHA fallito",
     "results_unavailable": "Risultati non disponibili",
     "unknown_error": "Errore sconosciuto"
   },

--- a/public/locales/nl.json
+++ b/public/locales/nl.json
@@ -65,6 +65,7 @@
       "not_supported": "Geolocatie wordt niet ondersteund"
     },
     "language_changed_refresh_to_reload_map": "Taal gewijzigd, vernieuw de pagina om de kaart opnieuw te laden",
+    "recaptcha_failed": "ReCAPTCHA mislukt",
     "results_unavailable": "Resultaten niet beschikbaar",
     "unknown_error": "Onbekende fout"
   },

--- a/public/locales/pl.json
+++ b/public/locales/pl.json
@@ -65,6 +65,7 @@
       "not_supported": "Geolokalizacja nie jest obsługiwana"
     },
     "language_changed_refresh_to_reload_map": "Język został zmieniony. Odśwież stronę, aby przeładować mapę",
+    "recaptcha_failed": "ReCAPTCHA nie powiodło się",
     "results_unavailable": "Wyniki niedostępne",
     "unknown_error": "Nieznany błąd"
   },

--- a/public/locales/pt.json
+++ b/public/locales/pt.json
@@ -65,6 +65,7 @@
       "not_supported": "Geolocalização não suportada"
     },
     "language_changed_refresh_to_reload_map": "Idioma alterado. Atualize a página para recarregar o mapa",
+    "recaptcha_failed": "Falha no ReCAPTCHA",
     "results_unavailable": "Resultados indisponíveis",
     "unknown_error": "Erro desconhecido"
   },

--- a/public/locales/ru.json
+++ b/public/locales/ru.json
@@ -65,6 +65,7 @@
       "not_supported": "Геолокация не поддерживается"
     },
     "language_changed_refresh_to_reload_map": "Язык изменен. Обновите страницу, чтобы перезагрузить карту",
+    "recaptcha_failed": "Ошибка проверки ReCAPTCHA",
     "results_unavailable": "Результаты недоступны",
     "unknown_error": "Неизвестная ошибка"
   },

--- a/public/locales/sv.json
+++ b/public/locales/sv.json
@@ -65,6 +65,7 @@
       "not_supported": "Platsinformation stöds inte"
     },
     "language_changed_refresh_to_reload_map": "Språk ändrat, uppdatera sidan för att ladda om kartan",
+    "recaptcha_failed": "ReCAPTCHA misslyckades",
     "results_unavailable": "Resultat inte tillgängliga",
     "unknown_error": "Okänt fel"
   },

--- a/public/locales/tr.json
+++ b/public/locales/tr.json
@@ -65,6 +65,7 @@
       "not_supported": "Konum özelliği desteklenmiyor"
     },
     "language_changed_refresh_to_reload_map": "Dil değiştirildi, haritayı yenilemek için sayfayı yenileyin",
+    "recaptcha_failed": "ReCAPTCHA başarısız oldu",
     "results_unavailable": "Sonuçlar mevcut değil",
     "unknown_error": "Bilinmeyen hata"
   },

--- a/public/locales/uk.json
+++ b/public/locales/uk.json
@@ -65,6 +65,7 @@
       "not_supported": "Геолокація не підтримується"
     },
     "language_changed_refresh_to_reload_map": "Мову змінено. Оновіть сторінку, щоб перезавантажити карту",
+    "recaptcha_failed": "Помилка перевірки ReCAPTCHA",
     "results_unavailable": "Результати недоступні",
     "unknown_error": "Невідома помилка"
   },

--- a/public/locales/vi.json
+++ b/public/locales/vi.json
@@ -65,6 +65,7 @@
       "not_supported": "Không hỗ trợ định vị"
     },
     "language_changed_refresh_to_reload_map": "Ngôn ngữ đã thay đổi, làm mới trang để tải lại bản đồ",
+    "recaptcha_failed": "ReCAPTCHA thất bại",
     "results_unavailable": "Kết quả không khả dụng",
     "unknown_error": "Lỗi không xác định"
   },

--- a/public/locales/zh-hans.json
+++ b/public/locales/zh-hans.json
@@ -65,6 +65,7 @@
       "not_supported": "不支持地理位置"
     },
     "language_changed_refresh_to_reload_map": "语言已更改，请刷新页面以重新加载地图",
+    "recaptcha_failed": "ReCAPTCHA 验证失败",
     "results_unavailable": "结果不可用",
     "unknown_error": "未知错误"
   },

--- a/public/locales/zh-hant.json
+++ b/public/locales/zh-hant.json
@@ -65,6 +65,7 @@
       "not_supported": "不支持地理位置"
     },
     "language_changed_refresh_to_reload_map": "語言已更改，請刷新頁面以重新加載地圖",
+    "recaptcha_failed": "ReCAPTCHA 驗證失敗",
     "results_unavailable": "結果無法取得",
     "unknown_error": "未知錯誤"
   },

--- a/src/components/connect/ConnectShare.js
+++ b/src/components/connect/ConnectShare.js
@@ -4,6 +4,8 @@ import { useLocation } from 'react-router-dom'
 
 import { LabelVisibility, MapType, OverlayType } from '../../constants/settings'
 import { setLanguageFromLocaleString } from '../../i18n'
+import { saveLocationFormValues } from '../../redux/locationSlice'
+import { saveReviewFormValues } from '../../redux/reviewSlice'
 import { updateSettings } from '../../redux/settingsSlice'
 import { updateSelection } from '../../redux/updateSelection'
 import { useAppHistory } from '../../utils/useAppHistory'
@@ -25,6 +27,9 @@ const ConnectShare = () => {
 
     const legacyMapType = searchParams.get('t')
     const legacyLabels = searchParams.get('l')
+
+    const reviewFormData = searchParams.get('reviewFormData')
+    const locationFormData = searchParams.get('locationFormData')
 
     const settingsUpdates = {}
 
@@ -76,6 +81,26 @@ const ConnectShare = () => {
     if (locale !== null) {
       setLanguageFromLocaleString(locale)
       history.removeParam('locale')
+    }
+
+    if (reviewFormData !== null) {
+      try {
+        const parsedReviewFormData = JSON.parse(reviewFormData)
+        dispatch(saveReviewFormValues(parsedReviewFormData))
+      } catch (e) {
+        console.error('[ConnectShare] Failed to parse reviewFormData', e)
+      }
+      history.removeParam('reviewFormData')
+    }
+
+    if (locationFormData !== null) {
+      try {
+        const parsedLocationFormData = JSON.parse(locationFormData)
+        dispatch(saveLocationFormValues(parsedLocationFormData))
+      } catch (e) {
+        console.error('[ConnectShare] Failed to parse locationFormData', e)
+      }
+      history.removeParam('locationFormData')
     }
 
     if (Object.keys(settingsUpdates).length > 0) {

--- a/src/components/form/LocationForm.js
+++ b/src/components/form/LocationForm.js
@@ -278,6 +278,7 @@ export const LocationForm = ({ editingId, innerRef }) => {
       })
     }
   }
+
   const handleCancel = (e) => {
     e.stopPropagation()
     if (editingId) {
@@ -288,8 +289,10 @@ export const LocationForm = ({ editingId, innerRef }) => {
   }
 
   const isLoggedIn = useSelector((state) => !!state.auth.user)
-  const { Recaptcha, handlePresubmit: onPresubmit } =
-    useInvisibleRecaptcha(handleSubmit)
+  const { Recaptcha, handlePresubmit: onPresubmit } = useInvisibleRecaptcha(
+    handleSubmit,
+    'locationFormData',
+  )
 
   return isLoading || typesAccess.isEmpty ? (
     <div>{t('layouts.loading')}</div>

--- a/src/components/form/ReviewForm.js
+++ b/src/components/form/ReviewForm.js
@@ -155,8 +155,10 @@ export const ReviewForm = ({ initialValues, editingId = null, innerRef }) => {
   }
 
   const isLoggedIn = useSelector((state) => !!state.auth.user)
-  const { Recaptcha, handlePresubmit: onPresubmit } =
-    useInvisibleRecaptcha(handleSubmit)
+  const { Recaptcha, handlePresubmit: onPresubmit } = useInvisibleRecaptcha(
+    handleSubmit,
+    'reviewFormData',
+  )
 
   return (
     <StyledForm>

--- a/src/components/form/formRoutes.js
+++ b/src/components/form/formRoutes.js
@@ -1,7 +1,7 @@
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
-import { Route, useParams } from 'react-router-dom'
+import { Route, useLocation, useParams } from 'react-router-dom'
 import styled from 'styled-components/macro'
 
 import { saveLocationFormValues } from '../../redux/locationSlice'
@@ -62,11 +62,22 @@ const DesktopButtonUnderForm = ({ formRef, saveFormValues }) => {
   return <SettingsButton onClick={handleClick} />
 }
 
+const useHasPendingUrlKey = (key) => {
+  const { search } = useLocation()
+  const searchParams = new URLSearchParams(search)
+  return searchParams.has(key)
+}
+
 const EditLocation = ({ NavComponent, withSettingsButton }) => {
   const history = useAppHistory()
   const formRef = useRef()
   const { locationId } = useParams()
   const { t } = useTranslation()
+  const isPending = useHasPendingUrlKey('locationFormData')
+
+  if (isPending) {
+    return null
+  }
 
   return (
     <>
@@ -93,6 +104,11 @@ const AddLocation = ({ NavComponent, backUrl, withSettingsButton }) => {
   const formRef = useRef()
   const dispatch = useDispatch()
   const { t } = useTranslation()
+  const isPending = useHasPendingUrlKey('locationFormData')
+
+  if (isPending) {
+    return null
+  }
 
   return (
     <>
@@ -122,6 +138,11 @@ const AddReview = ({ NavComponent, withSettingsButton }) => {
   const formRef = useRef()
   const { locationId } = useParams()
   const { t } = useTranslation()
+  const isPending = useHasPendingUrlKey('reviewFormData')
+
+  if (isPending) {
+    return null
+  }
 
   return (
     <>
@@ -148,6 +169,11 @@ const EditReview = ({ NavComponent, withSettingsButton }) => {
   const formRef = useRef()
   const { review } = useSelector((state) => state.review)
   const { t } = useTranslation()
+  const isPending = useHasPendingUrlKey('reviewFormData')
+
+  if (isPending) {
+    return null
+  }
 
   return (
     <>

--- a/src/components/form/useInvisibleRecaptcha.js
+++ b/src/components/form/useInvisibleRecaptcha.js
@@ -1,5 +1,6 @@
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'react-toastify'
 import Reaptcha from 'reaptcha'
 import styled from 'styled-components/macro'
 
@@ -18,6 +19,12 @@ export const useInvisibleRecaptcha = (handleSubmit, formValuesKey) => {
   const shareUrl = useShareUrl()
 
   const handlePresubmit = async (values, formikBag) => {
+    if (!navigator.onLine) {
+      toast.warning(t('error_message.connectivity.you_are_offline'))
+      formikBag.setSubmitting(false)
+      return
+    }
+
     submitArgsRef.current = { values, formikBag }
     await recaptchaRef.current.execute()
   }

--- a/src/components/form/useInvisibleRecaptcha.js
+++ b/src/components/form/useInvisibleRecaptcha.js
@@ -3,18 +3,23 @@ import { useTranslation } from 'react-i18next'
 import Reaptcha from 'reaptcha'
 import styled from 'styled-components/macro'
 
+import { useAppHistory } from '../../utils/useAppHistory'
+import useShareUrl from '../share/useShareUrl'
+
 const HiddenReaptcha = styled(Reaptcha)`
   visibility: hidden;
 `
 
-export const useInvisibleRecaptcha = (handleSubmit) => {
-  const { i18n } = useTranslation()
+export const useInvisibleRecaptcha = (handleSubmit, formValuesKey) => {
+  const { i18n, t } = useTranslation()
+  const history = useAppHistory()
   const recaptchaRef = useRef()
   const submitArgsRef = useRef()
+  const shareUrl = useShareUrl()
 
-  const handlePresubmit = (values, formikBag) => {
+  const handlePresubmit = async (values, formikBag) => {
     submitArgsRef.current = { values, formikBag }
-    recaptchaRef.current.execute()
+    await recaptchaRef.current.execute()
   }
 
   const handleVerify = (recaptchaResponse) => {
@@ -26,6 +31,26 @@ export const useInvisibleRecaptcha = (handleSubmit) => {
     )
   }
 
+  const navigateToFatalError = () => {
+    const { values } = submitArgsRef.current ?? {}
+    const fromPageUrl = new URL(shareUrl)
+    if (formValuesKey && values !== undefined) {
+      const serializedValues =
+        values?.review?.photos !== undefined
+          ? { ...values, review: { ...values.review, photos: [] } }
+          : values
+      fromPageUrl.searchParams.set(
+        formValuesKey,
+        JSON.stringify(serializedValues),
+      )
+    }
+
+    history.push('/error/fatal', {
+      errorMessage: t('error_message.recaptcha_failed'),
+      fromPage: fromPageUrl.toString(),
+    })
+  }
+
   const Recaptcha = () => (
     <HiddenReaptcha
       size="invisible"
@@ -34,6 +59,8 @@ export const useInvisibleRecaptcha = (handleSubmit) => {
         recaptchaRef.current = e
       }}
       onVerify={handleVerify}
+      onError={navigateToFatalError}
+      onExpire={navigateToFatalError}
       hl={i18n.language}
     />
   )

--- a/src/components/ui/Modal.js
+++ b/src/components/ui/Modal.js
@@ -48,8 +48,10 @@ const Modal = ({
   const isLoggedIn = useSelector((state) => !!state.auth.user)
   const isDesktop = useIsDesktop()
   const { t } = useTranslation()
-  const { Recaptcha, handlePresubmit: onPresubmit } =
-    useInvisibleRecaptcha(onSubmit)
+  const { Recaptcha, handlePresubmit: onPresubmit } = useInvisibleRecaptcha(
+    onSubmit,
+    null,
+  )
 
   return (
     <StyledModal

--- a/src/components/ui/PageTemplate.js
+++ b/src/components/ui/PageTemplate.js
@@ -248,7 +248,7 @@ const ErrorPage = ({ children }) => {
       <PageWrapper isDesktop={isDesktop}>
         {!isDesktop && (
           <MobileHeader>
-            <img src="/logo_orange.svg" alt="Falling Fruit logo" />
+            <img src="/logo_orange.svg" alt="Falling Fruit" />
           </MobileHeader>
         )}
         {children}


### PR DESCRIPTION
Closes #1003 

It looks like there's no way to recover from captcha failures (the API allows a reset, but it doesn't reliably work). Treat the error as fatal by going to /error/fatal. I'm preserving the state of the form, putting it in the URL, and repopulating on the way back, so at least a Reload will restore a description etc. that has been typed in.

Also, try to avoid failures in the first place by checking navigator.onLine - captcha won't work if this is false.

Easiest to test the commits separately - open a form in a private tab, fill in, set to offline, and submit. This should go to the error page in the first commit, and show a toast afterwards.