### PR TITLE
don't call syncViewToBrowserUrl from onChange handler after browser b…

### DIFF
--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -142,14 +142,14 @@ const clusterBounds = ({ lat, lng, zoom }) => {
     east: bounds.east * (360 / EARTH_CIRCUMFERENCE),
   }
 }
-const makeHandleViewChange = (dispatch, googleMap, history) => {
+const makeHandleViewChange = (dispatch, googleMap, history, setPopstate) => {
   const throttledDispatches = throttle((newView) => {
     dispatch(updateLastMapView(newView))
     dispatch(fetchLocations())
     dispatch(fetchFilterCounts())
   }, 1000)
 
-  return (googleMapReactCallbackArg) => {
+  return (popstateSinceLastSync) => (googleMapReactCallbackArg) => {
     const center = googleMap.getCenter()
     const newView = {
       center: { lat: center.lat(), lng: center.lng() },
@@ -159,8 +159,13 @@ const makeHandleViewChange = (dispatch, googleMap, history) => {
       height: googleMap.getDiv().offsetHeight,
     }
     throttledDispatches(newView)
-    if (googleMapReactCallbackArg) {
+
+    // Don't sync if bounds changed due to browser back button
+    if (!popstateSinceLastSync && googleMapReactCallbackArg) {
       history.syncViewToBrowserUrl(newView)
+    } else if (popstateSinceLastSync) {
+      // reset after first skip
+      setPopstate(false)
     }
   }
 }
@@ -202,6 +207,12 @@ const MapPage = ({ isDesktop }) => {
 
   const [draggedPosition, setDraggedPosition] = useState(null)
   const [shareOpen, setShareOpen] = useState(false)
+
+  // True if browser back button was hit since last call to `syncViewToBrowserUrl`
+  const [popstateSinceLastSync, setPopstateSinceLastSync] = useState(false)
+  const handlePopstate = (_event) => {
+    setPopstateSinceLastSync(true)
+  }
 
   const {
     initialView,
@@ -265,11 +276,13 @@ const MapPage = ({ isDesktop }) => {
         dispatch,
         googleMap,
         history,
+        setPopstateSinceLastSync,
       )
       /*
        * Call the handler for the first time since map (re)opened
+       * (popstateSinceLastSync)(googleMapReactCallbackArg)
        */
-      handleViewChangeRef.current(false)
+      handleViewChangeRef.current(false)(false)
     }
   }, [!typesAccess.isEmpty, googleMap, !!dispatch, hasTypesParams]) //eslint-disable-line
 
@@ -378,6 +391,20 @@ const MapPage = ({ isDesktop }) => {
     }
   }, [googleMap, getGoogleMaps, isViewingLocation, history])
 
+  /* Don't sync URL on browser back button: Using browser back button after
+   * navigating in the map widget causes map to pan/zoom which triggers
+   * GoogleMapReact onChange (bounds_changed) event. This means the url that
+   * the back button just popped out of history gets added right back. Also,
+   * if history.pushState is triggered programmatically (instead of by user
+   * action), it may be also be flagged by some browsers and lead to broken
+   * back button behavior. */
+  useEffect(() => {
+    window.addEventListener('popstate', handlePopstate)
+    return () => {
+      window.removeEventListener('popstate', handlePopstate)
+    }
+  }, [])
+
   const zoomIn = () => {
     googleMap?.setZoom(currentZoom + 1)
   }
@@ -472,7 +499,7 @@ const MapPage = ({ isDesktop }) => {
           layerTypes={layerTypes}
           defaultCenter={initialView.center}
           defaultZoom={initialView.zoom}
-          onChange={handleViewChangeRef.current}
+          onChange={handleViewChangeRef.current(popstateSinceLastSync)}
           onGoogleApiLoaded={({ map, maps }) => {
             map.mapTypes.set(
               'osm-standard',


### PR DESCRIPTION
…ack button navigation

closes https://github.com/falling-fruit/falling-fruit-web/issues/991

## Problem
- Back button causes map to pan -> triggers GoogleMapReact onChange event -> invokes syncViewToBrowserUrl which pushes the url that was just popped back into browser history -> duplicated entry in browser history -> user must hit browser back button twice for it to actually go back
- In some browsers (tested edge and chrome), back button seems to break after one use (stops going back or goes all the way back to new tab page). I'm convinced this is due to [user activation requirements](https://developer.mozilla.org/en-US/docs/Web/API/Window/popstate_event#when_popstate_is_sent): syncViewToBrowserUrl pushes to history while/immediately after popstate, maybe browser flags it and considers it not preceded by user interaction with the page.

Ideally syncViewToBrowserUrl is only called after user interaction event. maps api [does expose events for user interaction](https://developers.google.com/maps/documentation/javascript/events#EventsOverview), but not for user-initiated zoom/scroll.

## Partial solution
- set "back button pressed since last url sync" flag to true on popstate
- MapPage.js next attempt to sync url is ignored and the flag is set back to false
- only user-initiated map manipulations are synced to browser url

## Issues
Two race conditions, both arguably minor:
- back button -> valid map bounds-changing user input in rapid succession
- valid map bounds-changing user input -> back button in rapid succession
In both cases, the issue is that the popstate event fires before the map pan from valid user input finishes. As a result, the flag is set to true (skip sync) before onChange is fired, so the url isn't synced for one input. 