### PR TITLE
Update translation in zh-hans.json

### DIFF
--- a/public/locales/zh-hans.json
+++ b/public/locales/zh-hans.json
@@ -89,7 +89,7 @@
       "report": "举报/报告",
       "reset": "重置",
       "restart": "重新开始",
-      "review": "审核",
+      "review": "评价",
       "submit": "提交",
       "submitting": "提交中..."
     },
@@ -424,7 +424,7 @@
     "form": {
       "add_from_camera": "拍摄照片",
       "add_from_gallery": "从相册选择",
-      "leave_a_review": "发表评价/观察记录",
+      "leave_a_review": "发表评价",
       "observed_on": "观察日期 {{date}}",
       "photos": "现场照片"
     },
@@ -487,6 +487,6 @@
     "send": "发送邮件",
     "sign_in": "登录",
     "sign_out": "退出登录",
-    "your_activity": "我的动态"
+    "your_activity": "你的动态"
   }
 }

--- a/public/locales/zh-hans.json
+++ b/public/locales/zh-hans.json
@@ -1,26 +1,26 @@
 {
   "confirm_message": {
-    "delete_location": "您确定要删除这个位置吗？",
-    "delete_review": "您确定要删除这条评论吗？"
+    "delete_location": "确定要删除此地点吗？",
+    "delete_review": "确定要删除此评价吗？"
   },
   "devise": {
     "confirmations": {
-      "confirm_your_email": "确认您的电子邮件地址",
-      "confirmed": "您的电子邮件地址已成功确认。",
-      "no_token": "如果没有确认电子邮件，您将无法访问此页面。如果您确实来自确认电子邮件，请确保您使用了提供的完整 URL。",
-      "send_instructions": "您将在几分钟内收到一封电子邮件，其中包含有关如何确认您的电子邮件地址的说明。"
+      "confirm_your_email": "请验证你的邮箱",
+      "confirmed": "邮箱验证成功。",
+      "no_token": "你需要先验证邮箱才能访问此页面。如果你是通过邮件链接访问的，请确保链接完整。",
+      "send_instructions": "验证邮件已发送，请在几分钟内查收并按说明完成验证。"
     },
     "failure": {
-      "already_authenticated": "您已经登录。"
+      "already_authenticated": "你已登录。"
     },
     "passwords": {
-      "no_token": "如果没有密码重置电子邮件，您将无法访问此页面。如果您确实来自密码重置电子邮件，请确保您使用了提供的完整 URL。",
-      "send_instructions": "您将在几分钟内收到一封电子邮件，其中包含有关如何重置密码的说明。",
-      "updated_not_active": "您已经成功更改密码。"
+      "no_token": "无法访问此页面。如果你是从重置密码邮件跳转而来的，请确保链接完整。",
+      "send_instructions": "重置密码说明已发送至你的邮箱，请在几分钟内查收。",
+      "updated_not_active": "密码修改成功。"
     },
     "registrations": {
-      "update_needs_confirmation": "您已成功更新您的帐户，但我们需要验证您的新电子邮件地址。请检查您的电子邮件并按照确认链接确认您的新电子邮件地址。",
-      "updated": "您的帐户已成功更新。"
+      "update_needs_confirmation": "账户信息更新成功，但我们需要验证你的新邮箱地址。请登录新邮箱并点击确认链接。",
+      "updated": "账户信息已更新。"
     }
   },
   "error_message": {
@@ -28,13 +28,14 @@
       "add_location_list_failed": "添加位置列表失败：{{message}}",
       "add_location_to_list_failed": "添加位置到列表失败：{{message}}",
       "fetch_clusters_failed": "获取集群失败：{{message}}",
-      "fetch_import_failed": "获取数据集{{id}}失败：{{message}}",
-      "fetch_location_changes_failed": "获取位置变更失败：{{message}}",
+      "fetch_filter_counts_failed": "获取筛选统计失败：{{message}}",
+      "fetch_import_failed": "获取数据集 {{id}} 失败：{{message}}",
+      "fetch_location_changes_failed": "获取位置变更记录失败：{{message}}",
       "fetch_location_failed": "获取位置 {{id}} 失败：{{message}}",
       "fetch_location_lists_failed": "获取位置列表失败：{{message}}",
       "fetch_locations_failed": "获取位置失败：{{message}}",
-      "fetch_review_failed": "获取评论 {{id}} 失败：{{message}}",
-      "fetch_user_failed": "获取用户{{id}}失败：{{message}}",
+      "fetch_review_failed": "获取评价 {{id}} 失败：{{message}}",
+      "fetch_user_failed": "获取用户 {{id}} 失败：{{message}}",
       "location_deletion_failed": "删除位置失败：{{message}}",
       "location_edit_failed": "编辑位置失败：{{message}}",
       "location_submission_failed": "提交位置失败：{{message}}",
@@ -42,42 +43,43 @@
       "remove_location_from_list_failed": "从列表中移除位置失败：{{message}}",
       "remove_location_list_failed": "删除位置列表失败：{{message}}",
       "rename_location_list_failed": "重命名位置列表失败：{{message}}",
-      "report_submission_failed": "提交报告失败：{{message}}",
-      "review_deletion_failed": "删除评论失败：{{message}}",
-      "review_edit_failed": "编辑评论失败：{{message}}",
-      "review_submission_failed": "提交评论失败：{{message}}",
-      "street_view_unavailable": "位置 {{id}} 的街景视图不可用",
-      "type_add_failed": "添加新类型失败：{{message}}"
+      "report_submission_failed": "报告提交失败：{{message}}",
+      "review_deletion_failed": "评价删除失败：{{message}}",
+      "review_edit_failed": "评价编辑失败：{{message}}",
+      "review_submission_failed": "评价提交失败：{{message}}",
+      "street_view_unavailable": "地点 {{id}} 暂无街景视图",
+      "type_add_failed": "添加新类别失败：{{message}}"
     },
     "auth": {
-      "confirmation_failed": "账户确认失败：{{message}}",
-      "expired_refresh_token": "由于长时间未操作，我们已将您登出。请重新登录。",
+      "confirmation_failed": "账户验证失败：{{message}}",
+      "expired_refresh_token": "登录已过期，请重新登录。",
       "password_set_failed": "设置新密码失败：{{message}}",
       "profile_update_failed": "更新个人资料失败：{{message}}",
-      "resend_confirmation_failed": "重新发送确认失败：{{message}}",
+      "resend_confirmation_failed": "重新发送验证邮件失败：{{message}}",
       "reset_password_failed": "重置密码失败：{{message}}",
       "signin_failed": "登录失败：{{message}}",
       "signup_failed": "注册失败：{{message}}"
     },
     "connectivity": {
-      "you_are_back_online": "您已重新上线。",
-      "you_are_offline": "您已离线。"
+      "you_are_back_online": "网络已恢复。",
+      "you_are_offline": "你目前处于离线状态。"
     },
     "geolocation": {
-      "code_2": "位置不可用：{{message}}",
-      "code_3": "地理位置超时：{{message}}",
-      "denied": "获取您的位置权限被拒绝。要启用地理位置，请在浏览器设置中允许位置共享并刷新页面。",
-      "not_supported": "不支持地理位置"
+      "code_2": "无法定位：{{message}}",
+      "code_3": "定位超时：{{message}}",
+      "denied": "定位权限被拒绝。请在浏览器设置中开启位置共享并刷新页面。",
+      "not_supported": "当前浏览器不支持定位功能"
     },
-    "language_changed_refresh_to_reload_map": "语言已更改，请刷新页面以重新加载地图",
-    "unknown_error": "未知错误"
+    "language_changed_refresh_to_reload_map": "语言设置已更改，请刷新页面以更新地图",
+    "results_unavailable": "暂无结果",
+    "unknown_error": "发生未知错误"
   },
   "filter": {
     "all_types": "所有类型",
     "clear": "清除",
     "include_locations_from_tree_inventories": "包含树木清单位置",
-    "select_shown": "选择所有显示的",
-    "within_map_bounds": "在地图边界内"
+    "select_shown": "全选当前显示",
+    "within_map_bounds": "仅限地图范围内"
   },
   "form": {
     "button": {
@@ -86,26 +88,26 @@
       "delete": "删除",
       "edit": "编辑",
       "reload": "重新加载",
-      "report": "举报",
+      "report": "举报/报告",
       "reset": "重置",
       "restart": "重新开始",
       "review": "审核",
       "submit": "提交",
-      "submitting": "提交中"
+      "submitting": "提交中..."
     },
     "error": {
       "confirmation": "与原始内容不符",
-      "must_be_different": "必须与之前的值不同",
-      "too_short": "最少需要{{min}}个字符"
+      "must_be_different": "不能与旧值相同",
+      "too_short": "最少输入 {{min}} 个字符"
     },
     "not_signed_in": {
-      "continue": "继续",
-      "do_not_ask_again": "不再询问",
-      "message": "您尚未登录。继续以匿名方式操作，或先登录或注册以便稍后跟踪和管理此观察记录。",
+      "continue": "继续操作",
+      "do_not_ask_again": "不再提示",
+      "message": "你尚未登录。你可以继续以匿名身份操作，或者立即登录/注册以方便日后管理你的观察记录。",
       "title": {
-        "add_location": "匿名添加位置？",
-        "add_review": "匿名添加评论？",
-        "edit_location": "匿名编辑位置？"
+        "add_location": "以匿名身份添加地点？",
+        "add_review": "以匿名身份添加评价？",
+        "edit_location": "以匿名身份编辑地点？"
       }
     },
     "optional": "选填",
@@ -114,230 +116,224 @@
   },
   "glossary": {
     "about": "关于",
-    "account": "帐户",
-    "activity": "活动",
+    "account": "账户",
+    "activity": "动态",
     "address": "地址",
-    "by_author": "作者： {{author}}",
+    "by_author": "作者：{{author}}",
     "description": "描述",
-    "email": "电子邮件",
+    "email": "电子邮箱",
     "locations": {
-      "one": "位置",
-      "other": "位置"
+      "other": "地点"
     },
     "map": "地图",
     "name": "名称",
     "password": "密码",
     "quality": "质量",
     "review": {
-      "other": "评论"
+      "other": "评价"
     },
-    "sign_up": "报名",
+    "sign_up": "注册",
     "tree_inventory": {
       "one": "树木清单"
     },
     "type": {
-      "one": "类型",
-      "other": "类型"
+      "one": "类别",
+      "other": "类别"
     },
-    "unverified": "未经证实",
-    "yield": "屈服"
+    "unverified": "未验证",
+    "yield": "产量"
   },
   "info_message": {
-    "cannot_delete_location_with_other_reviews": "此地点包含其他用户的评论。如需要删除，请使用“报告”按钮。"
+    "cannot_delete_location_with_other_reviews": "此地点已有其他用户的评价。如需请求删除，请使用\"举报\"按钮。"
   },
   "layouts": {
     "application": {
       "menu": {
-        "in_the_press": "在新闻界",
+        "in_the_press": "媒体报道",
         "sharing_the_harvest": "分享收获",
-        "the_data": "数据",
-        "the_project": "该项目"
+        "the_data": "开放数据",
+        "the_project": "项目介绍"
       }
     },
     "back": "返回",
     "loading": "加载中..."
   },
   "list": {
-    "no_results": "未找到结果",
-    "zoom_in": "放大地图以查看位置数据"
+    "no_results": "未找到相关结果",
+    "zoom_in": "请放大地图以查看位置数据"
   },
   "locations": {
-    "add_new": "添加新的",
-    "add_similar": "添加类似的",
+    "add_new": "添加新地点",
+    "add_similar": "添加类似地点",
     "edit_position": {
-      "cancel": "取消编辑位置",
-      "confirm": "确认编辑位置",
-      "instructions": "编辑位置。"
+      "cancel": "取消位置修改",
+      "confirm": "保存位置修改",
+      "instructions": "拖动标记以修改位置。"
     },
     "form": {
-      "access": "访问",
-      "comments": "注释",
-      "comments_subtext": "更新、访问问题、植物健康......",
-      "description_subtext": "位置详细信息、访问问题、植物健康...",
-      "fruiting_status": "果实状态",
+      "access": "准入/权限",
+      "comments": "备注信息",
+      "comments_subtext": "关于维护、准入问题或植物健康状况...",
+      "description_subtext": "地点详情、采摘指南、生长情况...",
+      "fruiting_status": "结果状态",
       "position": "位置",
-      "season": "季节",
+      "season": "采摘季节",
       "season_start_to_stop_short": "至"
     },
     "index": {
-      "editmarker_html": "<b>移动到源的位置。</b><br><br>检查卫星视图 - 从太空中可以看到源！"
+      "editmarker_html": "<b>拖动到确切位置。</b><br><br>建议切换到卫星视图——有时可以从空中直接看到果树！"
     },
     "infowindow": {
       "access_mode": [
-        "来源在我的财产上",
-        "我已获得所有者的许可，可以添加来源",
-        "来源在公共土地上",
-        "来源在私人财产上，但悬在公共土地上",
-        "来源是私人财产（在您选择之前询问）"
+        "在我私人土地上",
+        "我已获得所有者许可",
+        "在公共土地上",
+        "在私人土地上，但枝条悬垂在公有区域",
+        "在私人土地上（采摘前请询问）"
       ],
       "access_short": [
-        "由所有者添加",
-        "业主允许",
-        "民众",
-        "私人但悬而未决",
-        "私人的"
+        "所有者添加",
+        "已获准",
+        "公共区域",
+        "私人（悬垂）",
+        "私人"
       ],
-      "fruiting": ["花蕾", "未成熟的水果", "熟了的果实"]
+      "fruiting": ["开花中", "果实未熟", "果实已熟"]
     },
     "init": {
-      "cancel": "取消选择位置",
-      "choose_instructions": "为您的新位置选择一个位置。",
-      "confirm": "确认选择位置",
-      "edit_instructions": "编辑您的新位置的位置。",
-      "position_too_close": "请选择与现有位置不同的位置"
+      "cancel": "取消选择",
+      "choose_instructions": "请在地图上选择新地点的位置。",
+      "confirm": "确认当前位置",
+      "edit_instructions": "调整新地点的位置。",
+      "position_too_close": "该位置与现有标记重合，请重新选择"
     },
     "overview": {
-      "added_by": "由{{name}}添加",
-      "added_by_you": "由您添加",
-      "date_edited": "更新于{{date}}",
-      "imported_from": "从{{name}}导入",
+      "added_by": "由 {{name}} 添加",
+      "added_by_you": "由你添加",
+      "date_edited": "更新于 {{date}}",
+      "imported_from": "导入自 {{name}}",
       "season": {
-        "in_season": "从{{start_month}}到{{stop_month}}的季节",
+        "in_season": "采摘期：{{start_month}} 至 {{stop_month}}",
         "year_round": "全年"
       },
       "title": "概览"
     }
   },
   "menu": {
-    "add_new_location": "添加位置",
-    "add_review": "添加评论",
-    "edit_location": "编辑位置",
-    "edit_review": "编辑评论",
+    "add_new_location": "添加地点",
+    "add_review": "添加评价",
+    "edit_location": "编辑地点",
+    "edit_review": "编辑评价",
     "filters": "筛选",
     "list": "列表",
     "settings": "设置",
-    "zoom_in_to_add_location": "放大以添加位置"
+    "zoom_in_to_add_location": "请放大地图以添加地点"
   },
   "new_type": {
-    "add_type_label": "添加类型：",
+    "add_type_label": "添加类别：",
     "form": {
-      "add_name": "添加名称",
+      "add_name": "类别名称",
       "language": "语言",
       "notes": "备注",
       "notes_placeholder": "描述、维基百科链接、分类信息...",
-      "pending_notice": "注意：所有新类型默认设置为待审核状态。只有管理员可以添加非待审核类型。",
-      "remove": "删除"
+      "pending_notice": "注意：所有新类别默认为\"待审核\"状态，通过管理员审核后生效。",
+      "remove": "移除"
     },
-    "title": "添加新类型"
+    "title": "添加新类别"
   },
   "pages": {
     "about": {
-      "about_the_site": "关于该项目",
+      "about_the_site": "关于本项目",
       "advisors": "顾问委员会",
-      "alan_gibson_bio_html": "艾伦一直喜欢冒险和探索。他开始觅食，以此向年幼的孩子介绍户外生活方式。他撰写了<a href=\"http://theurbaneforager.blogspot.com\">Urbane Forager</a>博客并出版了<a href=\"https://www.amazon.co.uk/Urbane-Forager-Fruit-Nuts-Free/dp/1785073001\">Urbane Forager：免费的水果和坚果</a>一书。他使在公园觅食合法化，并在他的家乡英国南安普顿建立了一个社区果园。",
-      "ali_moxley_bio_html": "Ali 与她的社区合作，传播关于蒙大拿州博兹曼市及周边地区生长的丰富水果和野生食物的意识。她的日常工作涉及与全国各地的食品和农业企业合作，识别并申请资金。周末她是一名业余记者，突出报道农村社区、农民和牧场主的故事。Ali 喜欢与朋友在树林中散步、觅食、康特拉舞蹈，以及反对我们食品系统的企业整合。",
-      "ana_carolina_bio_html": "Ana 是巴西帕拉联邦大学的博士后研究员。她是一位对了解社会和文化饮食习惯感兴趣的人类学家。安娜主要在巴西亚马逊地区工作。在 Acre（亚马逊西部），她研究了区域水果消费。然后，她在中索利梅斯地区工作，调查偏远社区的饮食变化。 2017 年至 2018 年间，安娜住在亚马逊三角洲的中小城镇，研究气候变化对非正规住区人们粮食安全的影响。她最近搬到了美国新墨西哥州南部，在那里担任顾问。",
-      "austin_arrington_bio_html": "自创立 <a href=\"https://plantgroupnyc.com\">PLANT Group</a> 以来，Austin 将工作重点放在支持更健康的生态系统和社区的气候技术上。作为一个三岁儿子的骄傲父亲，他在业余时间从事园艺、演奏音乐，并培养对本地食物和有韧性的基于地方的系统的深厚热情。",
-      "billy_daniels_bio_html": "Billy 对城市觅食的热爱始于一个简单的惊喜：在中西部长大后，在加利福尼亚朋友家的后院从树上摘下一个鳄梨。在旧金山生活期间，他总是在寻找湾区周围公众可以获取的水果。Billy 现在住在威斯康星州，在那里你可以看到他骑自行车、园艺，并经常光顾麦迪逊的许多农贸市场。他是一位产品管理领导者，热衷于推进 Falling Fruit 的使命，让新手更容易发现觅食。",
-      "caleb_phillips_bio_html": "Caleb 是一个没有羽毛的双足类人动物，热衷于食物正义，并寻找使用技术解决社会问题的创造性方法。当他不骑自行车四处瞅着树木时，他会在科罗拉多州戈尔登<a href=\"https://www.nrel.gov/research/caleb-phillips.html\">国家可再生能源实验室</a>的数据科学家和<a href=\"https://www.colorado.edu/cs/caleb-phillips\">科罗拉多大学</a>计算机科学副教授的日常工作之间平衡自己的努力。除了所有工作之外，他还喜欢攀岩、跑步、骑自行车，并且通常尽可能多地到户外。 Caleb 于 2013 年与 Ethan Welty 一起创建了 Falling Fruit，并在担任顾问委员会职务之前在董事会任职 6 年。",
-      "celebration": "Falling Fruit 庆祝我们城市街道上被忽视的美食。通过在交互式地图上量化此资源，我们希望促进人、食物和我们社区中生长的自然生物之间的密切联系。不只是免费的午餐！ 21 世纪的觅食是城市探索、对抗污迹斑斑的人行道的祸害以及与食物的植物起源重新联系的机会。",
-      "closing_remarks": "闭幕致辞",
-      "closing_remarks_para1_html": "Falling Fruit 是一家位于科罗拉多州博尔德的 501(c)(3)（免税）公共慈善机构。因此，美国境内的捐赠可以免税。您可以查看我们<a href=\"/501c3.pdf\">的 IRS 豁免函，</a><a href=\"http://apps.irs.gov/app/eos/pub78Search.do?\">并在 IRS 出版物 78</a>或<a href=\"http://www.sos.state.co.us/biz/BusinessEntityCriteriaExt.do?resetTransTyp=Y\">科罗拉多州国务卿处</a>核实我们的地位。还提供我们的<a href=\"https://docs.google.com/document/d/18E7PiiYbReq2c3BKYzxjHphiXsdtvkW-14UcN5y_5P4/edit?usp=sharing\">章程</a>和董事会会议<a href=\"https://docs.google.com/document/d/1fzqYZ7rxYfeVqDuvI_uAyWhKm50RilqdTz6oxx3Ohw4\">记录</a>。",
-      "closing_remarks_para2_html": "在城市环境中收获食物需要考虑某些实际和道德因素。对于城市觅食伦理的介绍，我们推荐以下<a href=\"https://docs.google.com/document/d/1SupIGQKC5Vgi3VYkdIQc05y_S7jSoZ4RTS-CzwlEAMY\">总结</a>。",
-      "closing_remarks_para3_html": "关于落果的信息可能是错误的或过时的。例如，迁移到 Falling Fruit 的许多觅食地图都作为公共 Google 地图托管，这些地图上的标记经常被意外移动，并且市政树木库存仅在（如果有的话）在访问树木进行维护时更新。准备好在现场遇到不准确的地方，请根据您的发现根据需要编辑地图。最终，您有责任确定植物的身份、可食用性和位置，并有责任提高地图的质量。",
-      "contact_us_html": "Falling Fruit 是为觅食者打造的，我们希望它成为当代觅食者可用的最佳工具。给我们写信<a href=\"mailto:feedback@fallingfruit.org\">反馈@fallingfruit.org</a> ，我们很乐意收到您的来信！",
-      "cristina_rubke_bio_html": "Cristina 是<a href=\"//sflaw.com/Bios/Rubke-Cristina-N.htm\">位于加利福尼亚州旧金山的 Shartsis Friese LLP 的律师</a>，她专注于商标起诉和咨询。<a href=\"//www.sfmta.com/\">她还是旧金山市交通局</a>的董事会成员，负责监督旧金山的公共交通、交通和停车。在业余时间，克里斯蒂娜与<a href=\"//www.baads.org/\">湾区残疾水手协会</a>一起在旧金山湾航行，并参加当地和国际帆船赛。",
-      "david_craft_bio_html": "David 是马萨诸塞州波士顿<a href=\"//gray.mgh.harvard.edu/index.php?option=com_content&view=article&id=4:david-craft-phd&catid=1:f\">哈佛医学院</a>放射肿瘤学系的研究员。他还是一位狂热的觅食者，并着有《<a href=\"//www.amazon.com/Urban-Foraging-finding-eating-plants-ebook/dp/B003LSTEGO/\">城市觅食：在城市中寻找和食用野生植物》</a> （<a href=\"https://drive.google.com/file/d/1vOp5-5B0BhCwBIxWlewUZYkXlp3fnv_P\">免费下载</a>）一书。",
+      "alan_gibson_bio_html": "Alan 一直热爱冒险和探索。为了向年幼的孩子介绍户外生活方式，他开始尝试野外觅食。他撰写了<a href=\"http://theurbaneforager.blogspot.com\">Urbane Forager</a>博客并出版了<a href=\"https://www.amazon.co.uk/Urbane-Forager-Fruit-Nuts-Free/dp/1785073001\">Urbane Forager：免费的水果和坚果</a>一书。他在家乡英国南安普顿成功推动了公园采摘合法化，并建立了一个社区果园。",
+      "ali_moxley_bio_html": "Ali 与其社区合作，致力于提高人们对蒙大拿州博兹曼市周边丰富野外食材的认识。她的本职工作是协助全国食品和农业企业申请资金。周末，她作为一名业余记者，记录农村社区和农牧民的故事。她热爱野外采摘、康特拉舞，并积极反对食品系统被企业化垄断。",
+      "ana_carolina_bio_html": "Ana 是巴西帕拉联邦大学的博士后研究员。作为一名人类学家，她致力于研究社会文化的饮食习惯，主要工作区域在巴西亚马逊地区。她曾研究亚马逊西部的区域水果消费和偏远社区的饮食变迁。2017-2018 年，她研究了气候变化对亚马逊三角洲非正式定居点粮食安全的影响。目前，她在美国新墨西哥州南部担任顾问。",
+      "austin_arrington_bio_html": "自创立 <a href=\"https://plantgroupnyc.com\">PLANT Group</a> 以来，Austin 专注于气候技术，以支持更健康的生态系统和社区。他是一位三岁男孩的父亲，业余时间喜欢园艺、演奏音乐，并对本土食物和韧性生态系统充满热忱。",
+      "billy_daniels_bio_html": "Billy 对城市觅食的热爱始于一次意外的惊喜：在中西部长大后，他在加州朋友家的后院亲手从树上摘下了一个牛油果。在旧金山生活期间，他总在寻找湾区的公共水果资源。目前他居住在威斯康星州，是一名产品经理，热衷于推广 Falling Fruit 的使命，让觅食变得更简单。",
+      "caleb_phillips_bio_html": "Caleb 是一位关注粮食正义的热血青年，致力于用技术手段解决社会问题。日常生活中，他在科罗拉多州戈尔登的<a href=\"https://www.nrel.gov/research/caleb-phillips.html\">国家可再生能源实验室</a>担任数据科学家，同时也是<a href=\"https://www.colorado.edu/cs/caleb-phillips\">科罗拉多大学</a>计算机科学系的副教授。他在 2013 年与 Ethan Welty 共同创建了 Falling Fruit。",
+      "celebration": "Falling Fruit 旨在发掘城市街道中被忽视的美食。通过交互式地图，我们将这些资源量化，以此重建人类、食物与自然生物之间的紧密联系。采摘不仅仅是为了免费午餐，更是城市探索、重返食物源头的机会。",
+      "closing_remarks": "结语",
+      "closing_remarks_para1_html": "Falling Fruit 是一家位于科罗拉多州博尔德的 501(c)(3) 非营利公共慈善机构。美国境内的捐赠可申请免税。你可以查看我们的 <a href=\"/501c3.pdf\">IRS 豁免函</a> 或在相关机构网站核实我们的地位。我们也公开了我们的 <a href=\"https://docs.google.com/document/d/18E7PiiYbReq2c3BKYzxjHphiXsdtvkW-14UcN5y_5P4/edit?usp=sharing\">章程</a> 和董事会会议 <a href=\"https://docs.google.com/document/d/1fzqYZ7rxYfeVqDuvI_uAyWhKm50RilqdTz6oxx3Ohw4\">记录</a>。",
+      "closing_remarks_para2_html": "在城市环境中采摘需要遵循实际和道德准则。有关城市采摘伦理的介绍，我们推荐阅读这份 <a href=\"https://docs.google.com/document/d/1SupIGQKC5Vgi3VYkdIQc05y_S7jSoZ4RTS-CzwlEAMY\">总结</a>。",
+      "closing_remarks_para3_html": "由于数据来源广泛（如过时的地图或市政维护信息），本站的信息可能存在误差或已失效。在前往实地之前，请做好遇到不实信息的准备，并根据你的发现实时修正地图。最终，辨别植物种类、确认可食用性以及判断具体位置的责任在于用户本人。",
+      "contact_us_html": "Falling Fruit 是为采摘者量身打造的，我们希望它能成为大家的最佳工具。如有任何意见，请致信 <a href=\"mailto:feedback@fallingfruit.org\">feedback@fallingfruit.org</a>。",
+      "cristina_rubke_bio_html": "Cristina是<a href=\"//sflaw.com/Bios/Rubke-Cristina-N.htm\">旧金山的一名律师，专注于商标法律咨询。她还是旧金山市交通局的董事会成员，负责监管公共交通和停车。业余时间，她通过残疾水手协会参与帆船运动，参加各种赛事。",
+      "david_craft_bio_html": "David 是哈佛医学院的研究员<a href=\"//gray.mgh.harvard.edu/index.php?option=com_content&view=article&id=4:david-craft-phd&catid=1:f\">，也是一位资深的采摘爱好者，著有《城市觅食：在城市中寻找和食用野生植物》一书<a href=\"//www.amazon.com/Urban-Foraging-finding-eating-plants-ebook/dp/B003LSTEGO/\"></a>（提供<a href=\"/docs/David Craft - Urban Foraging.pdf\">免费下载</a>）。",
       "directors": "董事会",
       "donate": "捐赠",
-      "ethan_welty_bio_html": "凭借技术和数据，Ethan 支持将城市作为新鲜和免费食物的来源。他于 2013 年与 Caleb Phillips 创建了 Falling Fruit，以促进全球城市觅食，并<a href=\"https://fruitrescue.org\">于 2014 年共同创立了 Community Fruit Rescue</a> ，以收获和分发他在科罗拉多州博尔德周围生长的剩余水果。除了水果，他还要兼顾<a href=\"https://www.weltyphotography.com\">摄影事业</a>、<a href=\"https://instaar.colorado.edu/people/ethan-welty/\">冰川研究</a>以及对山区和河流的追求。",
-      "ff_disclaimer_html": "落果与落果无关。 Fallen Fruit 可以在<a href=\"http://fallenfruit.org\">fallfruit.org</a>上找到。",
-      "give_us_money": "我们是一家 501(c)(3) 非营利组织，依靠捐款运营。如果您愿意并且有能力，请考虑做出经济贡献。在美国境内的捐款可以免税。",
+      "ethan_welty_bio_html": "Ethan 致力于利用技术和数据将城市转化为新鲜食物的来源。2013 年他与 Caleb 共同创建了 Falling Fruit，2014 年又共同创办了 <a href=\"https://fruitrescue.org\">Community Fruit Rescue</a>，旨在采摘和分发博尔德地区剩余的水果。此外，他还兼顾<a href=\"https://www.weltyphotography.com\">摄影事业</a>和<a href=\"https://instaar.colorado.edu/people/ethan-welty/\">冰川研究</a>。",
+      "ff_disclaimer_html": "本站 Falling Fruit 与同名艺术项目 Fallen Fruit 无关。Fallen Fruit 官网为 <a href=\"http://fallenfruit.org\">fallenfruit.org</a>。",
+      "give_us_money": "我们是一家依靠捐款运营的非营利组织。如果条件允许，请考虑给予我们资金支持。美国境内的捐款可免税。",
       "give_zeffy": "通过 Zeffy 捐赠",
-      "jeff_wanner_bio_html": "自从小时候与家人一起收获黑莓和蓝莓，以及最近注意到科罗拉多州各地公共果树的财富以来，杰夫对我们城市种植的丰富水果产生了深刻的认识。他在《落果》中的第一个任务是梳理博尔德和盐湖城，手里拿着纸质地图，记录果树。当不致力于提高建筑能源效率时，他通常会在社区中帮忙或步行、滑雪或骑自行车快速翻山越岭。",
-      "join_us_html": "与我们一起庆祝超级本地美食！<a href=\"/\">地图</a>开放给任何人编辑，数据库一键<a href=\"/about/data\">下载</a><a href=\"https://github.com/falling-fruit/\">，代码</a>开源。您也被鼓励与您的人类同胞分享赏金。我们的<a href=\"/about/sharing\">分享页面</a>列出了数百个当地组织 - 种植公共果园和食用林，从城市树木和农民的田地中采摘原本浪费的水果和蔬菜，并与邻居和有需要的人分享。",
-      "jp_goguen_bio_html": "JP 是<a href=\"https://library.illinois.edu\">伊利诺伊大学图书馆</a>的媒体技术专家，拥有艺术和信息科学背景。他居住在伊利诺伊州厄巴纳，绘制和拍摄当地野生食物网络，并组织社区觅食活动和技能分享。2025年，他的研究和故事收集促成了<a href=\"https://instagram.com/minipopuppawpawmuseum\">迷你弹出木瓜博物馆</a>的启动。当他不在图书馆时，他通常在<a href=\"https://rosebowltavern.com\">厄巴纳民谣聚会</a>上弹吉他，或者和他的狗 Dalí 一起打飞盘高尔夫。",
-      "meagan_shelley_bio_html": "Meagan 是一位企业主和博士候选人，居住在弗吉尼亚州中部。她是一名认证的<a href=\"https://vmga.net\">园艺大师</a>，住在一个10英亩的家园，种植水果、坚果和蔬菜，以及饲养鸡、鹌鹑和兔子。她的目标是实践闭环农业，这是一项持续进行的工作。与此同时，她努力觅食、种植和交换大约20-30%的年度食物供应。",
-      "more_about_html": "我们的可食用地图并非同类地图中的首创,但它渴望成为世界上最全面的地图。当我们的用户贡献他们自己的位置时,我们会在互联网上梳理已有的知识,力求将各地的觅食者、林务员和自由主义者的努力联合起来。<a href=\"/about/data\">导入的数据集</a>范围从小型社区觅食地图到大量专业编制的树木清单。到目前为止,这相当于数百万位置的数千种不同类型的食物(大多数,但不是全部,植物物种)。除了外来植物和被遗忘已久的本地植物的异国风味的栽培和常见之外,在您的社区觅食是一次穿越时间和跨文化的旅程。",
-      "staff": "职员",
+      "jeff_wanner_bio_html": "Jeff 从小就和家人一起采摘黑莓。他在 Falling Fruit 的早期任务是走遍博尔德和盐湖城，用纸质地图记录果树。他热衷于提高建筑能源效率，也热爱徒步和滑雪。",
+      "join_us_html": "加入我们！我们的 <a href=\"/\">地图</a> 开放编辑，数据库可一键 <a href=\"/about/data\">下载</a>，<a href=\"https://github.com/falling-fruit/\">代码</a> 亦完全开源。我们也鼓励你分享收获。我们的 <a href=\"/about/sharing\">分享页面</a> 列出了数百个致力于城市果园和食物分发的当地组织。",
+      "jp_goguen_bio_html": "JP 是伊利诺伊大学图书馆的媒体技术专家。他居住在伊利诺伊州厄巴纳，专注于绘制当地野生食物网络。2025 年，他创办了<a href=\"https://instagram.com/minipopuppawpawmuseum\">迷你弹出木瓜博物馆</a>。业余时间他通常在<a href=\"https://rosebowltavern.com\">厄巴纳民谣聚会</a>上弹吉他，或者和他的狗 Dalí 一起打飞盘高尔夫。",
+      "meagan_shelley_bio_html": "Meagan 居住在弗吉尼亚州中部，是一名企业主和博士候选人。作为认证的<a href=\"https://vmga.net\">园艺大师</a>，她在自己的家园种植蔬果并饲养禽畜。她的目标是实现闭环农业，目前她已能自给自足约 20-30% 的年度食物需求。",
+      "more_about_html": "我们的地图旨在成为全球最全面的城市食用植物图谱。通过用户的实时贡献以及对互联网已有知识（如市政树木清单、社区地图）的梳理，我们将各地的采摘者联合起来。目前，数据库已涵盖数百万个位置和数千个品种。在自己的社区采摘不仅是味觉探索，更是一次穿越时空的文化之旅。",
+      "staff": "工作人员",
       "translate": "翻译",
-      "translate_for_us_html": "有兴趣志愿担任翻译吗？给我们发电子邮件，我们会邀请您加入我们的<a href=\"https://phrase.com\">Phrase</a> ，我们的翻译在那里管理。",
-      "translators": "翻译员",
-      "tristram_stuart_bio_html": "十几岁的时候，崔斯特瑞姆靠从学校厨房、当地面包师和乡村蔬菜水果商那里收集的剩余食物养猪。注意到这些食物中有很多仍然适合人类食用，这让他意识到优质的新鲜食物正在被大规模浪费。自那以后，崔斯特瑞姆一直在不知疲倦地工作，以引起公众、媒体和政策制定者的注意。他创立了食物浪费运动组织“<a href=\"//feedbackglobal.org\">反馈全球”，</a>并撰写了《<a href=\"//tristramstuart.co.uk/\">浪费：揭开全球食物丑闻》</a>以在全球范围内展示问题的严重程度。 2011 年，崔斯特瑞姆因与食物浪费作斗争<a href=\"//www.sofieprisen.no/Prize_Winners/2011/index.html\">而获得苏菲奖。</a>",
-      "ward_bullard_bio_html": "Ward 是 31st Ventures 的合伙人，这是一家战略咨询公司。他最初是通过在 <a href=\"https://designforamerica.org\">Design for America</a> 的工作接触到 Falling Fruit 的，在那里他领导了两个组织之间的合作。作为所有水果（特别是邻里柿子）的爱好者，Ward 参与了多个设计和技术倡议，解决美国各地新鲜水果荒漠的问题，并很高兴为 Falling Fruit 的工作做出贡献。",
-      "write": "写"
+      "translate_for_us_html": "有兴趣成为翻译志愿者吗？请发邮件联系我们，我们会邀请你加入我们的翻译管理平台 <a href=\"https://phrase.com\">Phrase</a>。",
+      "translators": "翻译贡献者",
+      "tristram_stuart_bio_html": "Tristram 从青少年时期就开始利用剩余食物养猪，这让他意识到粮食浪费的严重性。他创立了\"<a href=\"//feedbackglobal.org\">反馈全球\"</a>\"组织，并撰写了《<a href=\"//tristramstuart.co.uk/\">浪费：揭开全球食物丑闻》</a> 一书。2011 年，他因此获得了苏菲奖。",
+      "ward_bullard_bio_html": "Ward 是 31st Ventures 的合伙人。他最初通过  <a href=\"https://designforamerica.org\">Design for America</a> 接触到本项目并促成了双方合作。他热爱邻里间的柿子树，积极推动技术手段解决美国各地的\"新鲜食品沙漠\"问题。",
+      "write": "撰稿"
     },
     "changes": {
-      "change_in_city": "在{{city}}{{type}}",
-      "days": {
-        "one": "{{count}} 天",
-        "other": "{{count}} 天"
-      },
-      "last_24_hours": "最近24小时",
+      "change_in_city": "在 {{city}} {{type}}",
       "place": {
         "one": "地点",
         "other": "地点"
       },
-      "recent_activity": "最近活动",
-      "time_ago": "{{time}}前",
+      "recent_activity": "最近动态",
       "type": {
-        "added": "添加",
-        "added_by_you": "由您添加",
-        "edited": "编辑",
-        "edited_by_you": "由您编辑",
-        "visited": "访问",
-        "visited_by_you": "由您访问"
+        "added": "新增",
+        "added_by_you": "由你新增",
+        "edited": "修改",
+        "edited_by_you": "由你修改",
+        "visited": "到访/审核",
+        "visited_by_you": "由你审核"
       },
-      "user_activity_empty": "该用户还没有添加、编辑或审核任何地点",
-      "your_activity_empty": "您还没有添加、编辑或审核任何地点"
+      "user_activity_empty": "该用户尚未添加、编辑或审核过任何地点",
+      "your_activity_empty": "你尚未添加、编辑或审核过任何地点"
     },
     "data": {
-      "caveat_emptor_html": "我们对数据的准确性不承担任何责任 - 它按原样提供，请<i>注意</i>。如果您对数据做了一些很酷的事情，请<a href=\"mailto:feedback@fallingfruit.org\">告诉我们</a>！",
-      "intro": "Falling Fruit 建立在公共数据和我们用户的慷慨之上。我们希望城市觅食能够惠及尽可能多的人，我们相信每个人都应该平等地获得我们集体劳动的成果。本着开放的精神，看！整个数据库：",
-      "license_html": "如果您有兴趣在您的项目中使用这些数据，尤其是商业项目，我们建议您联系我们（<a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a>）。除非另有说明，否则数据许可为<a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a>（知识共享 - 署名、非商业性、相同方式共享）。这意味着您可以自由使用和分发数据，只要您保留原始作者/来源署名，并且不（未经许可）将其用于商业应用。Falling Fruit 的源代码也已开放，可在<a href=\"https://github.com/falling-fruit/\">GitHub 上获得</a>。"
+      "beware_html": "提示：由于数据量巨大，解压后的文件可能会导致大多数 Excel 等电子表格软件卡死。如果你只需要特定区域的数据，请先尝试使用地图页面自带的下载工具。",
+      "caveat_emptor_html": "数据仅供参考，我们不保证其准确性。如果你利用这些数据做出了有趣的应用，请 <a href=\"mailto:feedback@fallingfruit.org\">联系我们</a>！",
+      "intro": "Falling Fruit 建立在公共数据和用户无私分享的基础之上。我们相信每个人都有权平等地获得我们集体劳动的成果。秉承开放精神，你可以下载我们的完整数据库：",
+      "license_html": "如果你希望在项目（特别是商业项目）中使用这些数据，请联系我们。除特别说明外，数据遵循 <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a> 许可协议。这意味着你可以自由使用和分发，但必须署名来源且不得用于商业用途。我们的源代码已在 <a href=\"https://github.com/falling-fruit/\">GitHub</a> 上开源。"
     },
     "datasets": {
       "community_map": "社区地图",
       "date_imported": "导入日期",
-      "import_id_and_name": "导入 #{{id}}: {{name}}",
+      "import_id_and_name": "导入 ID #{{id}}: {{name}}",
       "imported_datasets": "已导入的数据集",
       "imported_on": "导入于 {{date}}",
-      "intro_html": "Falling Fruit 立志成为最全面、最开放的城市食品地理数据集。当我们的用户使用我们的<a href=\"/\">地图</a>探索、编辑和添加位置时，我们将已知的宇宙梳理为预先存在的数据集并将它们直接导入数据库，联合各地的觅食者、林务员和自由主义者的努力。如果您知道我们遗漏的数据集，请<a href=\"mailto:info@fallingfruit.org\">告诉我们</a>！您还可以通过使用<a href=\"https://docs.google.com/spreadsheet/ccc?key=0AiHNFwLuWHvtdGVPamU2M0FZNFhpVTVSNXUtN3ZjRmc&usp=sharing\">导入模板</a>格式化数据来帮助我们完成导入过程。请注意，由于必须手动执行导入，因此导入后对原始数据所做的所有更改都不会反映在 Falling Fruit 上。",
+      "intro_html": "我们整合了全球各地的采摘者、林务员和志愿者的成果。如果你知道我们遗漏了哪些数据集，请 <a href=\"mailto:info@fallingfruit.org\">告知我们</a>！你也可以使用我们的 <a href=\"https://docs.google.com/spreadsheet/ccc?key=0AiHNFwLuWHvtdGVPamU2M0FZNFhpVTVSNXUtN3ZjRmc&usp=sharing\">模板</a> 协助我们导入数据。请注意，手动导入后的数据不会与原始来源同步更新。",
       "link": "链接",
-      "table_info": "每个数据集都按名称、位置数量和导入日期列出。展开每一行会显示有关数据、导入过程和管理数据使用方式的许可证的更多详细信息。",
+      "table_info": "数据集按名称、位置数量和导入日期排序。展开行可查看具体的授权许可和导入详情。",
       "type": "类型",
-      "types_of_data": "导入到 Falling Fruit 中的数据集分为两大类。 “社区地图”是由觅食者和自由主义者在他们仔细研究社区寻找食物时建立的。我们感谢辛勤工作的公民制图员，他们编制了这些数据。 “树木清单”由希望更好地记录和照顾树木的城市、大学和其他机构编制。我们为生产食物的物种挖掘这些庞大的数据集，并将它们添加到地图中。为了帮助我们绘制您附近的果树地图，请联系您的学校或城市，敦促他们与我们分享他们的树木清单。"
+      "types_of_data": "本站数据主要分为两类：\"社区地图\"由各地的采摘爱好者建立；\"树木清单\"则由城市、大学等机构编制。我们从庞大的清单中挖掘可生产食物的物种并标注在地图上。"
     },
     "network_error": {
-      "header_message": "网络错误",
-      "please_check_your_connection": "请检查您的连接并重试。",
-      "you_are_offline": "无法连接。看起来您已离线。"
+      "header_message": "网络异常",
+      "please_check_your_connection": "请检查你的网络连接并重试。",
+      "you_are_offline": "无法连接，你似乎处于离线状态。"
     },
     "settings": {
-      "bicycle": "自行车",
-      "label_visibility_header": "位置标签",
+      "bicycle": "自行车路径",
+      "label_visibility_header": "地点标签",
       "labels": {
         "always_on": "始终显示",
-        "off": "关闭",
-        "when_zoomed_in": "放大时显示"
+        "off": "不显示",
+        "when_zoomed_in": "仅在放大时显示"
       },
-      "language": "语言",
-      "points_of_interest": "兴趣点",
+      "language": "显示语言",
+      "points_of_interest": "景点",
       "regional": "区域",
-      "roadmap": "地图",
-      "satellite": "卫星",
-      "terrain": "地形",
-      "transit": "交通",
+      "roadmap": "标准地图",
+      "satellite": "卫星视图",
+      "terrain": "地形图",
+      "transit": "公共交通",
       "units": {
         "distance": {
           "foot": {
@@ -359,7 +355,7 @@
         },
         "imperial": "英制",
         "metric": "公制",
-        "units": "单位"
+        "units": "计量单位"
       }
     },
     "sharing": {
@@ -386,50 +382,50 @@
         "united_kingdom": "英国",
         "united_states": "美国"
       },
-      "grow_pick_and_distribute": "成长·挑选·分发",
+      "grow_pick_and_distribute": "种植·采摘·分发",
       "heading": {
         "city": "城市",
         "country": "国家",
-        "social": "社交",
+        "social": "社交媒体",
         "state": "州/省"
       },
-      "intro_html": "下面列出的是在公共场所种植食物（食物林、公共果园）、采摘食物（城市觅食、农场拾荒）或分发食物（交换、捐赠）的组织。组织按国家/地区、州（如果适用）和城市列出。那些名字被划掉的人被认为是不活跃的。如果您知道应该在此列表中的其他人，请<a href=\"mailto:info@fallingfruit.org\">与我们联系</a>！"
+      "intro_html": "以下是在公共场所种植食物、组织采摘或分发收获（交换、捐赠）的组织列表。名字被划掉的代表该组织可能已不活跃。如果你知道其他相关组织，请 <a href=\"mailto:info@fallingfruit.org\">联系我们</a>！"
     },
     "something_went_wrong": {
-      "email_us_if_this_persists_html": "如果问题仍然存在，请通过 <a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a> 告知我们。",
-      "error_occurred": "发生以下错误：{{message}}",
+      "email_us_if_this_persists_html": "如果问题持续出现，请通过 <a href=\"mailto:info@fallingfruit.org\">info@fallingfruit.org</a> 联系我们。",
+      "error_occurred": "错误详情：{{message}}",
       "header_message": "出错了"
     },
     "welcome": {
-      "community_driven_platform": "Falling Fruit是一个社区驱动的平台，用于分享可食用植物和其他免费食物的位置。",
-      "discover_and_contribute": "您可以发现其他人在您的社区里采摘的东西，并贡献您的观察。",
-      "explore_the_map": "探索地图",
-      "home_page": "主页",
+      "community_driven_platform": "Falling Fruit 是一个社区驱动的平台，旨在分享城市中可食用植物和其他免费食物的位置。",
+      "discover_and_contribute": "你可以探索邻里间的采摘记录，并分享你的发现。",
+      "explore_the_map": "开始探索地图",
+      "home_page": "首页",
       "welcome_visitors_to_the_site_short": "欢迎！"
     }
   },
   "problems": {
-    "description_subtext": "任何可能帮助我们评估问题的信息",
-    "problem_type": "问题类型",
+    "description_subtext": "请提供更多详情，以帮助我们核实问题",
+    "problem_type": "问题类别",
     "problem_types": [
-      "地点是垃圾信息",
+      "垃圾信息/广告",
       "地点不存在",
-      "地点是重复的",
-      "不当的评论照片",
-      "不当的评论内容",
+      "重复地点",
+      "照片不当",
+      "评论内容不当",
       "其他（请在下方说明）"
     ]
   },
   "review": {
     "form": {
-      "add_from_camera": "拍照",
+      "add_from_camera": "拍摄照片",
       "add_from_gallery": "从相册选择",
-      "leave_a_review": "发表评论",
-      "observed_on": "观察于 {{date}}",
-      "photos": "照片"
+      "leave_a_review": "发表评价/观察记录",
+      "observed_on": "观察日期 {{date}}",
+      "photos": "现场照片"
     },
-    "you_observed": "您于 {{date}} 观察了此地点",
-    "you_reviewed": "您于 {{date}} 评论了此地点"
+    "you_observed": "你于 {{date}} 观察了该地点",
+    "you_reviewed": "你于 {{date}} 评价了该地点"
   },
   "save_location_to_list": {
     "add_new_list": "添加新列表",
@@ -441,52 +437,61 @@
     "saved_locations_title": "已保存的位置"
   },
   "share": {
-    "leave_embed_view_for_full_site": "完整网站",
+    "leave_embed_view_for_full_site": "跳转至完整网站",
     "title": "分享此视图",
-    "url_copied": "网址已复制到剪贴板！",
-    "url_copy_failed": "复制网址到剪贴板失败"
+    "url_copied": "链接已复制！",
+    "url_copy_failed": "链接复制失败"
   },
   "success_message": {
-    "location_deleted": "位置删除成功！",
-    "location_edited": "位置已编辑",
-    "location_submitted": "位置已提交",
-    "report_submitted": "报告提交成功！",
-    "review_deleted": "评论已删除",
-    "review_edited": "评论已编辑",
-    "review_submitted": "评论已提交",
-    "type_added": "类型已添加"
+    "location_deleted": "地点已删除",
+    "location_edited": "修改已保存",
+    "location_submitted": "位置提交成功",
+    "report_submitted": "报告已提交",
+    "review_deleted": "评价已删除",
+    "review_edited": "评价已保存",
+    "review_submitted": "评价已提交",
+    "type_added": "类别已添加"
+  },
+  "time": {
+    "days": {
+      "one": "{{count}} 天",
+      "other": "{{count}} 天"
+    },
+    "last_24_hours": "最近 24 小时",
+    "time_ago": "{{time}}前"
   },
   "type": {
     "pending_review_category": "待审核",
-    "pending_review_item": "{{name}} (待审核)"
+    "pending_review_item": "{{name}}（审核中）"
   },
   "users": {
-    "bio": "关于你",
-    "change_email": "更改电子邮件",
-    "change_password": "更改密码",
+    "bio": "个人简介",
+    "change_email": "修改电子邮箱",
+    "change_password": "修改密码",
+    "change_your_password": "修改你的密码",
     "current_email": "当前邮箱",
     "current_password": "当前密码",
     "header": {
       "profile": "个人资料"
     },
-    "joined_on": "加入于 {{date}}",
-    "new_email": "新电子邮件",
+    "joined_on": "注册日期 {{date}}",
+    "new_email": "新邮箱",
     "new_password": "新密码",
     "new_password_confirmation": "确认新密码",
     "options": {
-      "announcements_email": "接收包含重要公告和机会的电子邮件（每年1-2次）"
+      "announcements_email": "接收重要公告和活动邮件（每年约 1-2 次）"
     },
     "password_confirmation": "确认密码",
     "profile": {
       "title": "用户：{{name}}"
     },
     "remember_me": "记住我",
-    "resend_confirmation_instructions": "重新发送确认说明",
+    "resend_confirmation_instructions": "重新发送验证说明",
     "reset_password": "重置密码",
     "save_changes": "保存更改",
-    "send": "发送",
+    "send": "发送邮件",
     "sign_in": "登录",
-    "sign_out": "退出",
-    "your_activity": "您的活动"
+    "sign_out": "退出登录",
+    "your_activity": "我的动态"
   }
 }

--- a/public/locales/zh-hans.json
+++ b/public/locales/zh-hans.json
@@ -28,7 +28,6 @@
       "add_location_list_failed": "添加位置列表失败：{{message}}",
       "add_location_to_list_failed": "添加位置到列表失败：{{message}}",
       "fetch_clusters_failed": "获取集群失败：{{message}}",
-      "fetch_filter_counts_failed": "获取筛选统计失败：{{message}}",
       "fetch_import_failed": "获取数据集 {{id}} 失败：{{message}}",
       "fetch_location_changes_failed": "获取位置变更记录失败：{{message}}",
       "fetch_location_failed": "获取位置 {{id}} 失败：{{message}}",
@@ -71,7 +70,6 @@
       "not_supported": "当前浏览器不支持定位功能"
     },
     "language_changed_refresh_to_reload_map": "语言设置已更改，请刷新页面以更新地图",
-    "results_unavailable": "暂无结果",
     "unknown_error": "发生未知错误"
   },
   "filter": {
@@ -123,6 +121,7 @@
     "description": "描述",
     "email": "电子邮箱",
     "locations": {
+      "one": "地点",
       "other": "地点"
     },
     "map": "地图",
@@ -280,11 +279,17 @@
     },
     "changes": {
       "change_in_city": "在 {{city}} {{type}}",
+      "days": {
+        "one": "{{count}} 天",
+        "other": "{{count}} 天"
+      },
+      "last_24_hours": "最近 24 小时",
       "place": {
         "one": "地点",
         "other": "地点"
       },
       "recent_activity": "最近动态",
+      "time_ago": "{{time}}前",
       "type": {
         "added": "新增",
         "added_by_you": "由你新增",
@@ -297,7 +302,6 @@
       "your_activity_empty": "你尚未添加、编辑或审核过任何地点"
     },
     "data": {
-      "beware_html": "提示：由于数据量巨大，解压后的文件可能会导致大多数 Excel 等电子表格软件卡死。如果你只需要特定区域的数据，请先尝试使用地图页面自带的下载工具。",
       "caveat_emptor_html": "数据仅供参考，我们不保证其准确性。如果你利用这些数据做出了有趣的应用，请 <a href=\"mailto:feedback@fallingfruit.org\">联系我们</a>！",
       "intro": "Falling Fruit 建立在公共数据和用户无私分享的基础之上。我们相信每个人都有权平等地获得我们集体劳动的成果。秉承开放精神，你可以下载我们的完整数据库：",
       "license_html": "如果你希望在项目（特别是商业项目）中使用这些数据，请联系我们。除特别说明外，数据遵循 <a rel=\"license\" href=\"http://creativecommons.org/licenses/by-nc-sa/4.0/\">CC BY-NC-SA</a> 许可协议。这意味着你可以自由使用和分发，但必须署名来源且不得用于商业用途。我们的源代码已在 <a href=\"https://github.com/falling-fruit/\">GitHub</a> 上开源。"
@@ -452,14 +456,6 @@
     "review_submitted": "评价已提交",
     "type_added": "类别已添加"
   },
-  "time": {
-    "days": {
-      "one": "{{count}} 天",
-      "other": "{{count}} 天"
-    },
-    "last_24_hours": "最近 24 小时",
-    "time_ago": "{{time}}前"
-  },
   "type": {
     "pending_review_category": "待审核",
     "pending_review_item": "{{name}}（审核中）"
@@ -468,7 +464,6 @@
     "bio": "个人简介",
     "change_email": "修改电子邮箱",
     "change_password": "修改密码",
-    "change_your_password": "修改你的密码",
     "current_email": "当前邮箱",
     "current_password": "当前密码",
     "header": {


### PR DESCRIPTION
Closes #1050
Revision Focus:

1. Standardization of Terminology: Unified "location" as "地点" (place) or "位置" (position), depending on the context.   Unified "review" as "评价" (review/evaluation) or "记录" (record).   Unified "account" as "账户".  

2. Removal of Redundant Particles:  Removed excessive use of possessives and determiners like "your," "this," or "a" to ensure the interface appears concise and professional.  

3. Idiomatic Rewriting: Corrected mistranslations, such as changing "yield" from "屈服" (to give in/surrender) to "产量" or "收获" (yield/harvest).   Refined "fruiting_status" from the literal "果实状态" to the more natural "结果情况" (fruiting condition).  

4. Correction of Mistranslations:  Fixed literal translation errors in biographical sketches and corrected biological terminology.