### PR TITLE
beta release

### DIFF
--- a/src/components/account/SavedLocationsPage.js
+++ b/src/components/account/SavedLocationsPage.js
@@ -286,7 +286,7 @@ const LocationRow = ({ location, listId, typesAccess }) => {
       }}
     >
       <LocationLink
-        to={`/locations-standalone/${location.id}/${viewToString(location.lat, location.lng, MIN_LOCATION_ZOOM)}`}
+        to={`/locations/${location.id}/${viewToString(location.lat, location.lng, MIN_LOCATION_ZOOM)}?pane=standalone`}
         onClick={handleLocationClick}
       >
         <LocationTypeDisplay location={location} typesAccess={typesAccess} />

--- a/src/components/account/SavedLocationsPage.js
+++ b/src/components/account/SavedLocationsPage.js
@@ -40,7 +40,7 @@ const TopRow = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 1.25rem;
+  margin-block-end: 0.5em;
 `
 
 const ListName = styled.h2`
@@ -53,7 +53,6 @@ const ExpandRow = styled.div`
   display: flex;
   align-items: center;
   gap: 6px;
-  padding: 0.6rem 1.25rem;
   cursor: ${({ $clickable }) => ($clickable ? 'pointer' : 'default')};
 `
 
@@ -98,8 +97,8 @@ const LocationItem = styled.li`
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0.5rem 1.25rem;
   border-bottom: 1px solid #efefef;
+  padding-block: 0.5em;
   position: relative;
 
   &:last-child {
@@ -111,7 +110,6 @@ const LocationLink = styled(Link)`
   color: ${theme.blue} !important;
   text-decoration: none;
   flex: 1;
-  font-size: 1rem;
 
   &:hover {
     text-decoration: underline;

--- a/src/components/activity/ActivityDiary.ts
+++ b/src/components/activity/ActivityDiary.ts
@@ -211,14 +211,11 @@ function transformActivityData(
           .map((typeId) => typesAccess.getType(typeId))
           .filter(Boolean)
 
+        const view = viewToString(change.lat, change.lng, MIN_LOCATION_ZOOM)
         const locationTypes: LocationTypes = {
           locationId: change.location_id,
           types,
-          url: `/locations-standalone/${change.location_id}/${viewToString(
-            change.lat,
-            change.lng,
-            MIN_LOCATION_ZOOM,
-          )}`,
+          url: `/locations/${change.location_id}/${view}?pane=standalone`,
           isSelected: true,
         }
         switch (change.description) {

--- a/src/components/auth/HomePage.js
+++ b/src/components/auth/HomePage.js
@@ -11,6 +11,7 @@ import {
   GeolocationState,
   requestGeolocation,
 } from '../../redux/geolocationSlice'
+import { viewToString } from '../../utils/appUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import AboutSection from '../mobile/AboutSection'
 import Button from '../ui/Button'
@@ -88,7 +89,7 @@ const HomePage = () => {
       history.push('/map')
     } else if (geolocation?.latitude && geolocation?.longitude) {
       history.push(
-        `/map/@${geolocation.latitude},${geolocation.longitude},${DEFAULT_GEOLOCATION_ZOOM}z`,
+        `/map/${viewToString(geolocation.latitude, geolocation.longitude, DEFAULT_GEOLOCATION_ZOOM)}`,
       )
     }
   }, [lastMapView, geolocation, geolocationState, history])

--- a/src/components/connect/ConnectLocation.js
+++ b/src/components/connect/ConnectLocation.js
@@ -20,6 +20,7 @@ import { setInitialView } from '../../redux/mapSlice'
 import { currentPathWithView, viewFromCurrentUrl } from '../../utils/appUrl'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { useIsDesktop, useIsEmbed } from '../../utils/useBreakpoint'
+import useLocationPane from '../entry/useLocationPane'
 import Button from '../ui/Button'
 
 const LessPaddingButton = styled(Button)`
@@ -83,16 +84,12 @@ const ConnectLocation = ({
   isBeingEditedPosition,
   isStreetView,
   isSuccessfullyAdded,
-  isStandalone,
 }) => {
   const dispatch = useDispatch()
   const { initialView, googleMap } = useSelector((state) => state.map)
   const hasInitialView = !!initialView
-  const {
-    position,
-    location,
-    pane: { drawerFullyOpen },
-  } = useSelector((state) => state.location)
+  const { position, location } = useSelector((state) => state.location)
+  const { drawerFullyOpen } = useLocationPane()
   const { isOpenInMobileLayout: filterOpen } = useSelector(
     (state) => state.filter,
   )
@@ -111,9 +108,6 @@ const ConnectLocation = ({
        * (e.g. location to settings and back)
        * so if data is present in redux, don't fetch
        * */
-      if (isStandalone) {
-        history.push(`/locations/${locationId}`)
-      }
       return
     }
     dispatch(
@@ -121,7 +115,6 @@ const ConnectLocation = ({
         locationId,
         isBeingEdited,
         isStreetView,
-        isStandalone,
         isFromEmbedViewMap: isEmbed,
       }),
     ).then((action) => {
@@ -148,10 +141,6 @@ const ConnectLocation = ({
         // to trigger component reload
         const newUrl = currentPathWithView(view)
         history.push(newUrl)
-      }
-
-      if (isStandalone) {
-        history.push(`/locations/${locationId}`)
       }
     })
   }, [dispatch, locationId]) //eslint-disable-line

--- a/src/components/connect/ConnectPath.js
+++ b/src/components/connect/ConnectPath.js
@@ -3,12 +3,11 @@ import { useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { viewFromCurrentUrl } from '../../utils/appUrl'
+import useLocationPane from '../entry/useLocationPane'
 
 const ConnectPath = () => {
   const { initialView, googleMap } = useSelector((state) => state.map)
-  const {
-    pane: { drawerFullyOpen },
-  } = useSelector((state) => state.location)
+  const { drawerFullyOpen } = useLocationPane()
   const { pathname } = useLocation()
   const hasInitialView = !!initialView
   const view = viewFromCurrentUrl()

--- a/src/components/connect/ConnectTopPanel.js
+++ b/src/components/connect/ConnectTopPanel.js
@@ -1,17 +1,16 @@
 import { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import { useDispatch } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import { closeFilter } from '../../redux/filterSlice'
 import { closeShare } from '../../redux/shareSlice'
+import useLocationPane from '../entry/useLocationPane'
 
 const ConnectTopPanel = () => {
   const dispatch = useDispatch()
   const location = useLocation()
   const isLocationsPath = location.pathname.startsWith('/locations')
-  const drawerFullyOpen = useSelector(
-    (state) => state.location.pane.drawerFullyOpen,
-  )
+  const { drawerFullyOpen } = useLocationPane()
 
   useEffect(
     () => () => {

--- a/src/components/connect/ConnectTypes.js
+++ b/src/components/connect/ConnectTypes.js
@@ -5,7 +5,7 @@ import { useDispatch } from 'react-redux'
 import { fetchAndLocalizeTypes } from '../../redux/typeSlice'
 import isNetworkError from '../../utils/isNetworkError'
 import { useAppHistory } from '../../utils/useAppHistory'
-import useShareUrl from '../share/useShareUrl'
+import { useShareUrl } from '../share/useStatefulUrl'
 
 const ConnectTypes = () => {
   const { i18n, t } = useTranslation()

--- a/src/components/connect/connectRoutes.js
+++ b/src/components/connect/connectRoutes.js
@@ -126,7 +126,6 @@ const connectRoutes = [
    * - sync property of being edited from URL routes to Redux
    * - sync property of being viewed in street view from URL routes to Redux
    * - on mobile, center and zoom on edited location
-   * - on mobile, keep track of whether we arrived via standalone URL
    * - on mobile, disable default overscroll (e.g. a refresh on scroll down in Chrome)
    * - on desktop, reset the fromSettings flag when leaving location
    * - when location id changes, drop fromSettings and userActivity state
@@ -139,7 +138,6 @@ const connectRoutes = [
       '/locations/:locationId/:nextSegment/:nextNextSegment',
       '/locations/:locationId/:nextSegment',
       '/locations/:locationId',
-      '/locations-standalone/:locationId',
     ]}
   >
     {({ match }) =>
@@ -152,7 +150,6 @@ const connectRoutes = [
           isBeingEditedPosition={match.params.nextNextSegment === 'position'}
           isStreetView={match.params.nextSegment === 'panorama'}
           isSuccessfullyAdded={match.params.nextSegment === 'success'}
-          isStandalone={match.path.startsWith('/locations-standalone')}
         />
       )
     }
@@ -288,7 +285,7 @@ const connectRoutes = [
    */
   <Route
     key="disconnect-activity"
-    path={['/users/:userId/activity', '/locations', '/locations-standalone']}
+    path={['/users/:userId/activity', '/locations']}
   >
     <DisconnectActivity />
   </Route>,
@@ -301,10 +298,7 @@ const connectRoutes = [
    *
    * action: clear lastViewedListPositionId when dismounting from list or location pages
    */
-  <Route
-    key="disconnect-last-viewed-position"
-    path={['/list', '/locations', '/locations-standalone']}
-  >
+  <Route key="disconnect-last-viewed-position" path={['/list', '/locations']}>
     <DisconnectLastViewedListPosition />
   </Route>,
 
@@ -316,10 +310,7 @@ const connectRoutes = [
    *
    * action: clear lastViewedListId when dismounting from account/lists or location pages
    */
-  <Route
-    key="disconnect-lists"
-    path={['/account/lists', '/locations', '/locations-standalone']}
-  >
+  <Route key="disconnect-lists" path={['/account/lists', '/locations']}>
     <DisconnectLists />
   </Route>,
 

--- a/src/components/desktop/SidePane.js
+++ b/src/components/desktop/SidePane.js
@@ -81,12 +81,7 @@ const SidePane = () => {
               <Header>{t('menu.settings')}</Header>
               <SettingsPage isDesktop />
             </Route>
-            <Route
-              path={[
-                '/locations/:locationId',
-                '/locations-standalone/:locationId',
-              ]}
-            >
+            <Route path="/locations/:locationId">
               {({ match }) =>
                 match && (
                   <>

--- a/src/components/embed/EmbedHeader.js
+++ b/src/components/embed/EmbedHeader.js
@@ -7,7 +7,7 @@ import styled from 'styled-components/macro'
 
 import { EMBED_HEADER_HEIGHT_PX } from '../../constants/mobileLayout'
 import { useAppHistory } from '../../utils/useAppHistory'
-import useShareUrl from '../share/useShareUrl'
+import { useShareUrl } from '../share/useStatefulUrl'
 import { AddLocationEmbed } from '../ui/AddLocation'
 import { zIndex } from '../ui/GlobalStyle'
 import ResetButton from '../ui/ResetButton'

--- a/src/components/entry/EntryMobile.js
+++ b/src/components/entry/EntryMobile.js
@@ -1,19 +1,13 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Skeleton from 'react-loading-skeleton'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
 
 import {
   NAVIGATION_BAR_HEIGHT_PX,
   TABS_HEIGHT_PX,
 } from '../../constants/mobileLayout'
-import {
-  fullyOpenPaneDrawer,
-  setPaneDrawerToLowPosition,
-  setPaneDrawerToMiddlePosition,
-  setTabIndex,
-} from '../../redux/locationSlice'
 import { useAppHistory } from '../../utils/useAppHistory'
 import DraggablePane from '../ui/DraggablePane'
 import { CardTabs, Tab, TabList, TabPanel, TabPanels } from './CardTabs'
@@ -22,6 +16,7 @@ import EntryOverview from './EntryOverview'
 import EntryReviews from './EntryReviews'
 import LightboxMobile from './LightboxMobile'
 import TopButtonsMobile from './TopButtonsMobile'
+import useLocationPane from './useLocationPane'
 
 const ENTRY_IMAGE_HEIGHT = 250
 
@@ -125,19 +120,20 @@ const TextContent = styled.article`
 
 const EntryMobile = () => {
   const { t } = useTranslation()
-  const dispatch = useDispatch()
   const history = useAppHistory()
+  const { reviews, isLoading } = useSelector((state) => state.location)
+
   const {
-    reviews,
-    isLoading,
-    pane: {
-      drawerFullyOpen,
-      drawerLow,
-      tabIndex,
-      isStandalone,
-      isFromEmbedViewMap,
-    },
-  } = useSelector((state) => state.location)
+    drawerFullyOpen,
+    drawerLow,
+    isStandalone,
+    isFromEmbedViewMap,
+    tabIndex,
+    fullyOpenPaneDrawer,
+    setPaneDrawerToMiddlePosition,
+    setPaneDrawerToLowPosition,
+    setTabIndex,
+  } = useLocationPane()
 
   const drawerDisabled = isFromEmbedViewMap || isStandalone
   const { isOpenInMobileLayout: filterOpen } = useSelector(
@@ -200,11 +196,11 @@ const EntryMobile = () => {
         }
         onPositionChange={(position) => {
           if (position === 'top') {
-            setTimeout(() => dispatch(fullyOpenPaneDrawer()), 0.25)
+            setTimeout(fullyOpenPaneDrawer, 0.25)
           } else if (position === 'middle') {
-            dispatch(setPaneDrawerToMiddlePosition())
+            setPaneDrawerToMiddlePosition()
           } else if (position === 'low') {
-            dispatch(setPaneDrawerToLowPosition())
+            setPaneDrawerToLowPosition()
           } else if (position === 'bottom') {
             history.push('/map')
           } else {
@@ -247,7 +243,7 @@ const EntryMobile = () => {
                 ? '0'
                 : 'env(safe-area-inset-top, 0)',
           }}
-          onChange={(index) => dispatch(setTabIndex(index))}
+          onChange={setTabIndex}
           index={tabIndex}
         >
           {drawerFullyOpen && hasReviews && (

--- a/src/components/entry/EntryOverview.js
+++ b/src/components/entry/EntryOverview.js
@@ -7,16 +7,12 @@ import {
 import { EditAlt, Map, User as UserYou } from '@styled-icons/boxicons-solid'
 import { useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { Link } from 'react-router-dom'
 import { css } from 'styled-components'
 import styled from 'styled-components/macro'
 
 import { MIN_LOCATION_ZOOM } from '../../constants/map'
-import {
-  reenablePaneDrawerAndSetToLowPosition,
-  setPaneDrawerToLowPosition,
-} from '../../redux/locationSlice'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { useIsDesktop, useIsEmbed } from '../../utils/useBreakpoint'
 import { theme } from '../ui/GlobalStyle'
@@ -28,6 +24,7 @@ import TypesHeader from './overview/TypesHeader'
 import { ReviewButton } from './ReviewButton'
 import ReviewSummary from './ReviewSummary'
 import { formatISOString, formatMonth } from './textFormatters'
+import useLocationPane from './useLocationPane'
 
 const hasSeasonality = (locationData) =>
   !!(
@@ -213,14 +210,19 @@ const EntryOverview = () => {
     streetViewOpen,
     locationId,
     location: locationData,
-    pane,
     reviews,
   } = useSelector((state) => state.location)
   const isEmbed = useIsEmbed()
   const { locationsWithoutPanorama } = useSelector((state) => state.misc)
   const user = useSelector((state) => state.auth.user)
-  const dispatch = useDispatch()
   const isDesktop = useIsDesktop()
+
+  const {
+    drawerFullyOpen,
+    isStandalone,
+    reenablePaneDrawerAndSetToLowPosition,
+    setPaneDrawerToLowPosition,
+  } = useLocationPane()
 
   const containerRef = useRef(null)
 
@@ -248,10 +250,10 @@ const EntryOverview = () => {
       })
       if (googleMap?.getZoom() < MIN_LOCATION_ZOOM) {
         googleMap?.setZoom(MIN_LOCATION_ZOOM)
-      } else if (pane.isStandalone) {
-        dispatch(reenablePaneDrawerAndSetToLowPosition())
-      } else if (pane.drawerFullyOpen) {
-        dispatch(setPaneDrawerToLowPosition())
+      } else if (isStandalone) {
+        reenablePaneDrawerAndSetToLowPosition()
+      } else if (drawerFullyOpen) {
+        setPaneDrawerToLowPosition()
       }
     }
   }
@@ -268,10 +270,7 @@ const EntryOverview = () => {
   return (
     <OverviewContainer ref={containerRef}>
       <>
-        <TypesHeader
-          types={types}
-          openable={pane.drawerFullyOpen || isDesktop}
-        />
+        <TypesHeader types={types} openable={drawerFullyOpen || isDesktop} />
         <Tags locationData={locationData} />
         <Description>
           <p dir="auto">{locationData.description}</p>

--- a/src/components/entry/TopButtonsMobile.js
+++ b/src/components/entry/TopButtonsMobile.js
@@ -3,18 +3,15 @@ import {
   Pencil as PencilIcon,
   Trash as TrashIcon,
 } from '@styled-icons/boxicons-solid'
-import { useDispatch, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 import styled from 'styled-components/macro'
 
-import {
-  reenablePaneDrawerAndSetToLowPosition,
-  setPaneDrawerToMiddlePosition,
-} from '../../redux/locationSlice'
 import { useAppHistory } from '../../utils/useAppHistory'
 import { zIndex } from '../ui/GlobalStyle'
 import IconButton from '../ui/IconButton'
 import ReturnIcon from '../ui/ReturnIcon'
 import { useDeleteLocation } from './useDeleteLocation'
+import useLocationPane from './useLocationPane'
 
 const StyledButtons = styled.div`
   position: absolute;
@@ -64,12 +61,14 @@ EntryButton.defaultProps = {
 }
 
 const TopButtonsMobile = ({ hasImages }) => {
-  const dispatch = useDispatch()
   const history = useAppHistory()
+  const { locationId } = useSelector((state) => state.location)
   const {
-    locationId,
-    pane: { isStandalone, isFromEmbedViewMap },
-  } = useSelector((state) => state.location)
+    isStandalone,
+    isFromEmbedViewMap,
+    setPaneDrawerToMiddlePosition,
+    reenablePaneDrawerAndSetToLowPosition,
+  } = useLocationPane()
   const { id: recentChangesSectionId } = useSelector(
     (state) => state.activity.recentChanges.lastBrowsedSection,
   )
@@ -88,7 +87,7 @@ const TopButtonsMobile = ({ hasImages }) => {
         : recentChangesSectionId
           ? '/changes'
           : '/list'
-    history.push(standaloneBackPath)
+    history.push(`${standaloneBackPath}?pane=&tab=`)
   }
 
   return (
@@ -101,7 +100,7 @@ const TopButtonsMobile = ({ hasImages }) => {
               ? () => history.push('/map')
               : (e) => {
                   e.stopPropagation()
-                  dispatch(setPaneDrawerToMiddlePosition())
+                  setPaneDrawerToMiddlePosition()
                 }
         }
         icon={<ReturnIcon />}
@@ -112,7 +111,7 @@ const TopButtonsMobile = ({ hasImages }) => {
           <EntryButton
             onClick={(event) => {
               event.stopPropagation()
-              dispatch(reenablePaneDrawerAndSetToLowPosition())
+              reenablePaneDrawerAndSetToLowPosition()
             }}
             icon={<MapIcon />}
             label="map-button"

--- a/src/components/entry/overview/SaveToListButton.js
+++ b/src/components/entry/overview/SaveToListButton.js
@@ -234,10 +234,14 @@ const SaveToListButton = ({ containerRef }) => {
     setNewListName('')
   }
 
-  const handleConfirmNewList = () => {
+  const handleConfirmNewList = async () => {
     const trimmed = newListName.trim()
     if (trimmed) {
-      dispatch(addList({ name: trimmed }))
+      const resultAction = await dispatch(addList({ name: trimmed }))
+      if (addList.fulfilled.match(resultAction)) {
+        const newList = resultAction.payload
+        dispatch(addLocationToList({ listId: newList.id, location }))
+      }
     }
     setAddingNew(false)
     setNewListName('')

--- a/src/components/entry/useDeleteLocation.js
+++ b/src/components/entry/useDeleteLocation.js
@@ -18,7 +18,7 @@ export const useDeleteLocation = () => {
     if (confirm(t('confirm_message.delete_location'))) {
       dispatch(deleteExistingLocation(locationId)).then((result) => {
         if (result.type.endsWith('/fulfilled')) {
-          history.push('/map')
+          history.push('/map?pane=&tab=')
           toast.success(t('success_message.location_deleted'))
         } else if (result.type.endsWith('/rejected')) {
           toast.error(

--- a/src/components/entry/useLocationPane.js
+++ b/src/components/entry/useLocationPane.js
@@ -50,9 +50,15 @@ const useLocationPane = () => {
       }
 
       const nextSearch = next.toString()
-      history.replace({
+      const nextSearchString = nextSearch ? `?${nextSearch}` : ''
+
+      if (nextSearchString === search) {
+        return
+      }
+
+      history.push({
         pathname,
-        search: nextSearch ? `?${nextSearch}` : '',
+        search: nextSearchString,
       })
     },
     [history, pathname, search],

--- a/src/components/entry/useLocationPane.js
+++ b/src/components/entry/useLocationPane.js
@@ -1,0 +1,110 @@
+import { useCallback } from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
+
+import { useIsEmbed } from '../../utils/useBreakpoint'
+
+/**
+ * Manages location pane state via URL search params.
+ *
+ * URL params:
+ *   pane = 'low' | 'full' | 'standalone' | (absent = middle)
+ *   tab  = '1'   | (absent = 0)
+ *
+ * Returns an object with the same shape as state.location.pane in Redux,
+ * plus functions to mutate the state.
+ */
+const useLocationPane = () => {
+  const history = useHistory()
+  const { search, pathname } = useLocation()
+  const isEmbed = useIsEmbed()
+
+  const params = new URLSearchParams(search)
+  const paneParam = params.get('pane') // 'low' | 'full' | 'standalone' | null
+  const tabParam = params.get('tab') // '1' | null
+
+  const isStandalone = paneParam === 'standalone'
+  const isFromEmbedViewMap = isEmbed
+  const drawerFullyOpen =
+    paneParam === 'full' || isStandalone || isFromEmbedViewMap
+  const drawerLow = paneParam === 'low'
+  const tabIndex = drawerFullyOpen && tabParam === '1' ? 1 : 0
+
+  const setParams = useCallback(
+    (newPaneValue, newTabValue) => {
+      const next = new URLSearchParams(search)
+
+      if (newPaneValue === null || newPaneValue === undefined) {
+        next.delete('pane')
+      } else {
+        next.set('pane', newPaneValue)
+      }
+
+      if (
+        newTabValue === null ||
+        newTabValue === undefined ||
+        newTabValue === 0
+      ) {
+        next.delete('tab')
+      } else {
+        next.set('tab', String(newTabValue))
+      }
+
+      const nextSearch = next.toString()
+      history.replace({
+        pathname,
+        search: nextSearch ? `?${nextSearch}` : '',
+      })
+    },
+    [history, pathname, search],
+  )
+
+  const setPaneParam = useCallback(
+    (newPaneValue) => {
+      // If we're moving away from fully open, clear the tab index
+      const isLeavingFullyOpen = drawerFullyOpen && newPaneValue !== 'full'
+      setParams(
+        newPaneValue,
+        isLeavingFullyOpen ? null : tabIndex === 0 ? null : tabIndex,
+      )
+    },
+    [setParams, tabIndex, drawerFullyOpen],
+  )
+
+  const fullyOpenPaneDrawer = useCallback(() => {
+    setPaneParam('full')
+  }, [setPaneParam])
+
+  const setPaneDrawerToMiddlePosition = useCallback(() => {
+    setPaneParam(null)
+  }, [setPaneParam])
+
+  const setPaneDrawerToLowPosition = useCallback(() => {
+    setPaneParam('low')
+  }, [setPaneParam])
+
+  const reenablePaneDrawerAndSetToLowPosition = useCallback(() => {
+    setPaneParam('low')
+  }, [setPaneParam])
+
+  const setTabIndex = useCallback(
+    (index) => {
+      setParams(paneParam, index === 0 ? null : index)
+    },
+    [setParams, paneParam],
+  )
+
+  return {
+    drawerFullyOpen,
+    drawerLow,
+    isStandalone,
+    isFromEmbedViewMap,
+    tabIndex,
+    fullyOpenPaneDrawer,
+    setPaneDrawerToMiddlePosition,
+    setPaneDrawerToLowPosition,
+    reenablePaneDrawerAndSetToLowPosition,
+    setTabIndex,
+  }
+}
+
+export default useLocationPane

--- a/src/components/init/Auth.js
+++ b/src/components/init/Auth.js
@@ -7,7 +7,7 @@ import { checkAuth } from '../../redux/authSlice'
 import { pathToSignInPage } from '../../utils/appUrl'
 import isNetworkError from '../../utils/isNetworkError'
 import { useAppHistory } from '../../utils/useAppHistory'
-import useShareUrl from '../share/useShareUrl'
+import { useShareUrl } from '../share/useStatefulUrl'
 
 const AuthInitializer = () => {
   const dispatch = useDispatch()

--- a/src/components/list/ListPage.js
+++ b/src/components/list/ListPage.js
@@ -73,7 +73,7 @@ const ListPage = () => {
       }
       onLocationClick={(locationPosition) => {
         dispatch(setLastViewedListPositionState(locationPosition))
-        history.push(`/locations-standalone/${locationPosition.id}`)
+        history.push(`/locations/${locationPosition.id}?pane=standalone`)
       }}
     />
   )

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -344,7 +344,7 @@ const MapPage = ({ isDesktop }) => {
       if (isDesktop && pathname.includes('/settings')) {
         dispatch(setFromSettings(true))
       }
-      history.push(`/locations/${location.id}`)
+      history.push(`/locations/${location.id}?pane=&tab=`)
     },
     [isDesktop, pathname, dispatch, history],
   )
@@ -365,7 +365,7 @@ const MapPage = ({ isDesktop }) => {
       'click',
       () => {
         if (isViewingLocation) {
-          history.push('/map')
+          history.push('/map?pane=&tab=')
         }
       },
     )

--- a/src/components/mobile/MobileLayout.js
+++ b/src/components/mobile/MobileLayout.js
@@ -8,6 +8,7 @@ import {
   NAVIGATION_BAR_HEIGHT_PX,
   TABS_HEIGHT_PX,
 } from '../../constants/mobileLayout'
+import { isViewSegment } from '../../utils/appUrl'
 import { useIsEmbed } from '../../utils/useBreakpoint'
 import aboutRoutes from '../about/aboutRoutes'
 import accountRoutes from '../account/accountRoutes'
@@ -70,7 +71,7 @@ const shouldDisplayMapPage = (pathname) => {
   const locationId =
     match?.params.locationId && parseInt(match.params.locationId)
   const isViewingLocation =
-    locationId && match.params.nextSegment?.indexOf('@') === 0
+    locationId && isViewSegment(match.params.nextSegment)
 
   const isEditingLocationMarker =
     locationId &&

--- a/src/components/share/Share.js
+++ b/src/components/share/Share.js
@@ -8,7 +8,7 @@ import { closeShare } from '../../redux/shareSlice'
 import Button from '../ui/Button'
 import CloseButton from '../ui/CloseButton'
 import Input from '../ui/Input'
-import useShareUrl from './useShareUrl'
+import { useShareUrl } from './useStatefulUrl'
 
 const ShareContainer = styled.div`
   display: flex;

--- a/src/components/share/useStatefulUrl.js
+++ b/src/components/share/useStatefulUrl.js
@@ -3,8 +3,13 @@ import { useMemo } from 'react'
 import { useSelector } from 'react-redux'
 
 import { LabelVisibility, MapType } from '../../constants/settings'
+import {
+  applyLegacyViewParams,
+  currentPathWithoutViewSegment,
+  viewFromCurrentUrl,
+} from '../../utils/appUrl'
 
-const useShareUrl = () => {
+const useStatefulUrl = ({ baseUrl, useLegacyViewParams }) => {
   const { mapType, labelVisibility, overlay, showBusinesses } = useSelector(
     (state) => state.settings,
   )
@@ -16,36 +21,64 @@ const useShareUrl = () => {
     [typeEncoder, types],
   )
 
-  const baseUrl = Capacitor.isNativePlatform()
-    ? 'https://fallingfruit.org'
-    : window.location.origin
-  const url = new URL(
-    baseUrl + window.location.pathname + window.location.search,
-  )
+  const pathname = useLegacyViewParams
+    ? currentPathWithoutViewSegment()
+    : window.location.pathname
+
+  const url = new URL(baseUrl + pathname + window.location.search)
+
   if (url.pathname.startsWith('/filters')) {
     url.pathname = url.pathname.replace(/^\/filters/, '/map')
   }
+
   url.searchParams.delete('embed')
+
+  if (useLegacyViewParams) {
+    applyLegacyViewParams(url.searchParams, viewFromCurrentUrl())
+  }
+
   if (mapType !== MapType.Roadmap) {
     url.searchParams.set('map', mapType)
   }
+
   const labelParam = LabelVisibility.toUrlParam(labelVisibility)
   if (labelParam !== null) {
     url.searchParams.set('labels', labelParam)
   }
+
   if (overlay) {
     url.searchParams.set('overlay', overlay)
   }
+
   if (!muni) {
     url.searchParams.set('muni', 'false')
   }
+
   if (showBusinesses) {
     url.searchParams.set('poi', 'true')
   }
+
   if (encodedTypes !== 'default') {
     url.searchParams.set('types', encodedTypes)
   }
+
   return url.toString()
 }
 
-export default useShareUrl
+const useShareUrl = () => {
+  const baseUrl = Capacitor.isNativePlatform()
+    ? 'https://fallingfruit.org'
+    : window.location.origin
+
+  return useStatefulUrl({ baseUrl, useLegacyViewParams: false })
+}
+
+const useRestartUrl = () => {
+  const fullUrl = useStatefulUrl({
+    baseUrl: window.location.origin,
+    useLegacyViewParams: true, //avoid misparsing dot in Capacitor
+  })
+  return fullUrl.replace(window.location.origin, '')
+}
+
+export { useRestartUrl, useShareUrl }

--- a/src/components/ui/Button.js
+++ b/src/components/ui/Button.js
@@ -20,7 +20,6 @@ const StyledButton = styled(ResetButton)`
   box-sizing: border-box;
   border-radius: 0.375em;
   padding: 0 10px;
-  // TODO: make raised and add a location button in main pane
 
   ${({ isDesktop, secondary }) =>
     isDesktop &&
@@ -47,7 +46,6 @@ const Icon = styled.span`
   ${prepend('margin-inline', '0.25em')}
 `
 
-// TODO: forward ref and remaining props in all UI components, rather than taking specific props
 const Button = ({
   secondary = false,
   leftIcon,

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -107,7 +107,6 @@ const setLanguageFromLocaleString = (locale) => {
 const LanguageSelect = () => {
   const { t, i18n } = useTranslation()
   const { googleMap } = useSelector((state) => state.map)
-  const [hasToasted, setHasToasted] = useState(false)
   const [pendingLanguage, setPendingLanguage] = useState(null)
   const restartUrl = useRestartUrl()
   return (
@@ -120,15 +119,12 @@ const LanguageSelect = () => {
           setPendingLanguage(null)
           persistentStore.setLanguage(option.value)
           setDocumentDir(option.value)
-          if (!hasToasted && googleMap) {
-            if (Capacitor.isNativePlatform()) {
-              window.location.href = restartUrl
-            } else {
-              toast.info(
-                t('error_message.language_changed_refresh_to_reload_map'),
-              )
-              setHasToasted(true)
-            }
+          if (Capacitor.isNativePlatform()) {
+            window.location.href = restartUrl
+          } else if (googleMap) {
+            toast.info(
+              t('error_message.language_changed_refresh_to_reload_map'),
+            )
           }
         })
       }}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -7,6 +7,7 @@ import { initReactI18next, useTranslation } from 'react-i18next'
 import { useSelector } from 'react-redux'
 import { toast } from 'react-toastify'
 
+import { useRestartUrl } from './components/share/useStatefulUrl'
 import Select from './components/ui/SingleSelect'
 import persistentStore from './utils/persistentStore'
 
@@ -108,6 +109,7 @@ const LanguageSelect = () => {
   const { googleMap } = useSelector((state) => state.map)
   const [hasToasted, setHasToasted] = useState(false)
   const [pendingLanguage, setPendingLanguage] = useState(null)
+  const restartUrl = useRestartUrl()
   return (
     <Select
       options={LANGUAGE_OPTIONS}
@@ -120,7 +122,7 @@ const LanguageSelect = () => {
           setDocumentDir(option.value)
           if (!hasToasted && googleMap) {
             if (Capacitor.isNativePlatform()) {
-              window.location.reload()
+              window.location.href = restartUrl
             } else {
               toast.info(
                 t('error_message.language_changed_refresh_to_reload_map'),

--- a/src/redux/locationSlice.js
+++ b/src/redux/locationSlice.js
@@ -31,13 +31,6 @@ const initialState = {
     reviewIndex: null,
     photoIndex: null,
   },
-  pane: {
-    drawerFullyOpen: false,
-    drawerLow: false,
-    isStandalone: false,
-    isFromEmbedViewMap: false,
-    tabIndex: 0,
-  },
   isBeingInitializedMobile: false,
 }
 
@@ -144,26 +137,6 @@ const locationSlice = createSlice({
       state.lightbox.reviewIndex = action.payload.reviewIndex
       state.lightbox.photoIndex = action.payload.photoIndex
     },
-    reenablePaneDrawerAndSetToLowPosition: (state) => {
-      state.pane.isStandalone = false
-      state.pane.drawerFullyOpen = false
-      state.pane.drawerLow = true
-    },
-    fullyOpenPaneDrawer: (state) => {
-      state.pane.drawerFullyOpen = true
-      state.pane.drawerLow = false
-    },
-    setPaneDrawerToMiddlePosition: (state) => {
-      state.pane.drawerFullyOpen = false
-      state.pane.drawerLow = false
-    },
-    setPaneDrawerToLowPosition: (state) => {
-      state.pane.drawerFullyOpen = false
-      state.pane.drawerLow = true
-    },
-    setTabIndex: (state, action) => {
-      state.pane.tabIndex = action.payload
-    },
     setFromSettings: (state, action) => {
       state.fromSettings = action.payload
     },
@@ -181,11 +154,6 @@ const locationSlice = createSlice({
       state.form = null
       state.tooltipOpen = action.meta.arg.isBeingEdited
       state.streetViewOpen = action.meta.arg.isStreetView
-      state.pane.isStandalone = action.meta.arg.isStandalone
-      state.pane.isFromEmbedViewMap = action.meta.arg.isFromEmbedViewMap
-      state.pane.drawerFullyOpen =
-        action.meta.arg.isStandalone || action.meta.arg.isFromEmbedViewMap
-      state.pane.tabIndex = 0
       state.inList = false
     },
     [fetchLocationData.fulfilled]: (state, action) => {
@@ -325,11 +293,6 @@ export const {
   openLightbox,
   closeLightbox,
   setLightboxIndices,
-  reenablePaneDrawerAndSetToLowPosition,
-  setTabIndex,
-  fullyOpenPaneDrawer,
-  setPaneDrawerToMiddlePosition,
-  setPaneDrawerToLowPosition,
   setFromSettings,
   setIsBeingInitializedMobile,
 } = locationSlice.actions

--- a/src/utils/appUrl.js
+++ b/src/utils/appUrl.js
@@ -36,7 +36,8 @@ export const legacyViewFromSearchParams = (searchParams) => {
 const findViewSegmentIndex = (pathname) => {
   const parts = pathname.split('/')
   for (let i = parts.length - 1; i >= 0; i--) {
-    if (VIEW_SEGMENT_REGEX.test(parts[i])) {
+    const partWithoutParams = parts[i].split('?')[0]
+    if (VIEW_SEGMENT_REGEX.test(partWithoutParams)) {
       return pathname.lastIndexOf(`/${parts[i]}`)
     }
   }
@@ -71,13 +72,27 @@ export const applyLegacyViewParams = (searchParams, view) => {
   searchParams.set('z', String(view.zoom))
 }
 
+const dropEmptyParams = (searchParams) => {
+  const keysToDelete = []
+  for (const [key, value] of searchParams.entries()) {
+    if (value === '') {
+      keysToDelete.push(key)
+    }
+  }
+  keysToDelete.forEach((key) => searchParams.delete(key))
+}
+
 const pathComponentsToString = (path, view, searchParams) => {
   const urlParts = []
-  urlParts.push(path.replace(/\/*$/, ''))
+  urlParts.push(path.replace(/\/*$/, '')) // */
 
   if (view) {
     urlParts.push('/')
     urlParts.push(viewToString(view.center.lat, view.center.lng, view.zoom))
+  }
+
+  if (searchParams) {
+    dropEmptyParams(searchParams)
   }
 
   const searchString = searchParams?.toString()
@@ -101,14 +116,17 @@ const legacyViewFromCurrentUrl = () => {
 const parseViewFromCurrentUrl = () => {
   const { pathname } = new URL(window.location.href)
   const parts = pathname.split('/')
-  const viewSegment = parts.find((part) => VIEW_SEGMENT_REGEX.test(part))
+  const viewSegment = parts.find((part) =>
+    VIEW_SEGMENT_REGEX.test(part.split('?')[0]),
+  )
 
   if (!viewSegment) {
     return null
   }
 
   const parsedUrlValues = viewSegment
-    .substring(0, viewSegment.length - 1)
+    .split('?')[0]
+    .substring(0, viewSegment.split('?')[0].length - 1)
     .split(',')
 
   const lat = parseFloat(parsedUrlValues[0])
@@ -132,13 +150,22 @@ export const pathWithCurrentView = (path) => {
     return path
   }
 
+  // Split any params off the incoming path and merge them into the search params
+  const [pathWithoutParams, incomingSearch] = path.split('?')
+  const incomingParams = new URLSearchParams(incomingSearch)
+
   const { search } = new URL(window.location.href)
   const searchParams = new URLSearchParams(search)
   searchParams.delete('fromPage')
 
+  // Merge incoming params into searchParams (incoming params take precedence)
+  for (const [key, value] of incomingParams.entries()) {
+    searchParams.set(key, value)
+  }
+
   const currentView = viewFromCurrentUrl()
   if (currentView) {
-    return pathComponentsToString(path, currentView, searchParams)
+    return pathComponentsToString(pathWithoutParams, currentView, searchParams)
   }
 
   const legacyView = legacyViewFromSearchParams(searchParams)
@@ -146,10 +173,10 @@ export const pathWithCurrentView = (path) => {
     searchParams.delete('x')
     searchParams.delete('y')
     searchParams.delete('z')
-    return pathComponentsToString(path, legacyView, searchParams)
+    return pathComponentsToString(pathWithoutParams, legacyView, searchParams)
   }
 
-  return pathComponentsToString(path, null, searchParams)
+  return pathComponentsToString(pathWithoutParams, null, searchParams)
 }
 
 export const currentPathWithView = (view) => {

--- a/src/utils/appUrl.js
+++ b/src/utils/appUrl.js
@@ -2,6 +2,9 @@ const DEFAULT_LAT = 40.1125785
 const DEFAULT_LNG = -88.2287926
 const DEFAULT_ZOOM = 4
 
+const VIEW_SEGMENT_REGEX =
+  /^\-?[0-9]+(e[0-9]+)?(\.[0-9]+)?,\-?[0-9]+(e[0-9]+)?(\.[0-9]+)?,[1-9]\d*z$/
+
 const validateLatLngZoom = (lat, lng, zoom) => {
   if (isNaN(lat) || isNaN(lng) || isNaN(zoom)) {
     return null
@@ -30,16 +33,42 @@ export const legacyViewFromSearchParams = (searchParams) => {
   return null
 }
 
+const findViewSegmentIndex = (pathname) => {
+  const parts = pathname.split('/')
+  for (let i = parts.length - 1; i >= 0; i--) {
+    if (VIEW_SEGMENT_REGEX.test(parts[i])) {
+      return pathname.lastIndexOf(`/${parts[i]}`)
+    }
+  }
+  return -1
+}
+
 const pathWithoutView = (path) => {
-  const stateIndex = path.indexOf('/@')
+  const stateIndex = findViewSegmentIndex(path)
   return stateIndex === -1 ? path : path.substring(0, stateIndex)
+}
+
+export const currentPathWithoutViewSegment = () => {
+  const { pathname } = new URL(window.location.href)
+  return pathWithoutView(pathname)
 }
 
 export const viewToString = (lat, lng, zoom) => {
   // 7 decimal places gives precision to 1 cm
   // Normalize longitude to -180 to 180 range
   const normalizedLng = ((lng + 540) % 360) - 180
-  return `@${lat.toFixed(7)},${normalizedLng.toFixed(7)},${zoom}z`
+  return `${lat.toFixed(7)},${normalizedLng.toFixed(7)},${zoom}z`
+}
+
+export const applyLegacyViewParams = (searchParams, view) => {
+  if (!view) {
+    return
+  }
+  const { lat, lng } = view.center
+  const normalizedLng = ((lng + 540) % 360) - 180
+  searchParams.set('x', normalizedLng.toFixed(7))
+  searchParams.set('y', lat.toFixed(7))
+  searchParams.set('z', String(view.zoom))
 }
 
 const pathComponentsToString = (path, view, searchParams) => {
@@ -68,17 +97,18 @@ const legacyViewFromCurrentUrl = () => {
   const searchParams = new URLSearchParams(search)
   return legacyViewFromSearchParams(searchParams)
 }
+
 const parseViewFromCurrentUrl = () => {
   const { pathname } = new URL(window.location.href)
-  const geocoordMatch = pathname.substring(pathname.indexOf('@'))
+  const parts = pathname.split('/')
+  const viewSegment = parts.find((part) => VIEW_SEGMENT_REGEX.test(part))
 
-  const urlFormatMatchRegex =
-    /^@\-?[0-9]+(e[0-9]+)?(\.[0-9]+)?,\-?[0-9]+(e[0-9]+)?(\.[0-9]+)?,[1-9]\d*z$/
-  if (!geocoordMatch || !urlFormatMatchRegex.test(geocoordMatch)) {
+  if (!viewSegment) {
     return null
   }
-  const parsedUrlValues = geocoordMatch
-    .substring(1, geocoordMatch.length - 1)
+
+  const parsedUrlValues = viewSegment
+    .substring(0, viewSegment.length - 1)
     .split(',')
 
   const lat = parseFloat(parsedUrlValues[0])
@@ -98,7 +128,7 @@ export const pathToSignInPage = () => {
 }
 
 export const pathWithCurrentView = (path) => {
-  if (path.startsWith('#') || path.indexOf('/@') !== -1) {
+  if (path.startsWith('#') || findViewSegmentIndex(path) !== -1) {
     return path
   }
 
@@ -139,3 +169,5 @@ export const addParam = (url, paramName, paramValue) => {
 
 export const pathWithView = (path, view) =>
   pathComponentsToString(pathWithoutView(path), view, null)
+
+export const isViewSegment = (segment) => VIEW_SEGMENT_REGEX.test(segment)

--- a/src/utils/useBreakpoint.js
+++ b/src/utils/useBreakpoint.js
@@ -25,13 +25,10 @@ const useBreakpoint = ({
 }
 
 const getIsEmbed = () => {
-  if (typeof window !== 'undefined') {
-    const urlParams = new URLSearchParams(window.location.search)
-    const isEmbedParam = urlParams.get('embed') === 'true'
-    const isEmbedPath = window.location.pathname.startsWith('/locations/embed')
-    return isEmbedParam || isEmbedPath
-  }
-  return false
+  const urlParams = new URLSearchParams(window.location.search)
+  const isEmbedParam = urlParams.get('embed') === 'true'
+  const isEmbedPath = window.location.pathname.startsWith('/locations/embed')
+  return isEmbedParam || isEmbedPath
 }
 
 const useIsEmbed = () => {


### PR DESCRIPTION
Closes #1070 

@ezwelty how do you feel about an enhancement to drop `@` from the view syntax? I've confused myself with the test cases I used and gone in completely the wrong direction, wrote code to change how we store path segments, and then it didn't solve the issue. Easy to put it back in or remove but now that I look at the URL without `@`, I like it a bit more, and now is a great time to change URLs.


Closes #1068
I made the change to keep drawer state in params. Same commit because it also changes `src/utils/appUrl.js` a lot. It's definitely better - for example there's a skeleton loader shown when going from list to location - and we could maybe use params whenever there's a separate app view, like in the report modal.

On the other hand, it's harder to write transitions in this way. When keeping state in Redux, you can observe changes in state and make dispatches asynchronously, and have separate files for each individual tiny thing like e.g. a location marker on a map, but with url params, they start to clash with each other and make race conditions.

We have code for managing URLs to maintain view and params, so I added a new rule to it - a param with empty value is dropped - and whenever I navigate away from the context of panes I add `?pane=&tab=` to reset the pane and tab.

Closes #1076 
Closes #1078
