### PR TITLE
Better photos

### DIFF
--- a/src/constants/photo.js
+++ b/src/constants/photo.js
@@ -11,4 +11,4 @@ export const PHOTO_MAX_DIMENSION = 2048
  *
  * @constant {number}
  */
-export const JPEG_QUALITY = 0.85
+export const JPEG_QUALITY = 0.8

--- a/src/constants/photo.js
+++ b/src/constants/photo.js
@@ -4,11 +4,11 @@
  * Photos are downsized (if needed) while maintaining their aspect ratio.
  * @constant {number}
  */
-export const PHOTO_MAX_DIMENSION = 1200
+export const PHOTO_MAX_DIMENSION = 2048
 
 /**
  * JPEG compression quality for photos, between 0 and 1.
  *
  * @constant {number}
  */
-export const JPEG_QUALITY = 0.8
+export const JPEG_QUALITY = 0.85


### PR DESCRIPTION
Closes #1080 

I've assembled an experimental setup of objects of varying colors in diffuse lighting, took two pictures, and uploaded: https://falling-fruit-web.pages.dev/locations/1989825/@55.8258624,-4.2610278,18z .

 I can tell the better one from the lighting on the window frame for example. Sizes are 162kb and 460kb, so still the same ballpark - I think the slow uploads I originally tried to fix were from pictures weighing a few megabytes. Agreeing with you @ezwelty  that the resizing was too aggressive, thanks for pointing it out!