### PR TITLE
Scroll into view

### DIFF
--- a/src/components/entry/overview/SaveToListButton.js
+++ b/src/components/entry/overview/SaveToListButton.js
@@ -169,6 +169,7 @@ const SaveToListButton = ({ containerRef }) => {
   const wrapperRef = useRef(null)
   const newListInputRef = useRef(null)
   const addingNewSkeletonRef = useRef(null)
+  const addNewRowRef = useRef(null)
 
   const { lists } = useSavedLists(locationId)
   const { drawerFullyOpen, fullyOpenPaneDrawer } = useLocationPane()
@@ -190,7 +191,26 @@ const SaveToListButton = ({ containerRef }) => {
   useEffect(() => {
     if (addingNew && newListInputRef.current) {
       newListInputRef.current.focus()
+      addNewRowRef.current?.scrollIntoView()
     }
+  }, [addingNew])
+
+  // Re-scroll after soft keyboard appears on mobile
+  useEffect(() => {
+    if (!addingNew) {
+      return
+    }
+    const viewport = window.visualViewport
+    if (!viewport) {
+      return
+    }
+
+    const handleViewportResize = () => {
+      addNewRowRef.current?.scrollIntoView()
+    }
+
+    viewport.addEventListener('resize', handleViewportResize)
+    return () => viewport.removeEventListener('resize', handleViewportResize)
   }, [addingNew])
 
   useEffect(() => {
@@ -307,7 +327,7 @@ const SaveToListButton = ({ containerRef }) => {
           <BottomSection>
             <Divider />
             {addingNew ? (
-              <AddNewRow>
+              <AddNewRow ref={addNewRowRef}>
                 <AddNewInput
                   ref={newListInputRef}
                   value={newListName}


### PR DESCRIPTION
Closes #1072

For me, this commit makes a difference between the keyboard impinging onto the field about third of the way and being fully visible. @ezwelty I'm definitely guessing and looking for cheap fixes here but would you try this one?

Also, I notice that the soft keyboard appearance also moves the image and tabs up, which is not possible with a normal scroll. It's a feature rather than bug. I had a go at a re-engineer of the location drawer
thinking it could be quite good for the full pane to behave like a normal website but it was unfortunately hard, not working, and I abandoned it.
