### PR TITLE
Say why the map is stuck when it is

### DIFF
--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
+import { toast } from 'react-toastify'
 import styled from 'styled-components/macro'
 
 import { VISIBLE_CLUSTER_ZOOM_LIMIT } from '../../constants/map'
@@ -144,9 +145,13 @@ const clusterBounds = ({ lat, lng, zoom }) => {
 }
 const makeHandleViewChange = (dispatch, googleMap, history) => {
   const throttledDispatches = throttle((newView) => {
-    dispatch(updateLastMapView(newView))
-    dispatch(fetchLocations())
-    dispatch(fetchFilterCounts())
+    try {
+      dispatch(updateLastMapView(newView))
+      dispatch(fetchLocations())
+      dispatch(fetchFilterCounts())
+    } catch (error) {
+      toast.error(error?.message ?? error)
+    }
   }, 1000)
 
   return () => {

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -149,7 +149,7 @@ const makeHandleViewChange = (dispatch, googleMap, history) => {
     dispatch(fetchFilterCounts())
   }, 1000)
 
-  return (googleMapReactCallbackArg) => {
+  return () => {
     const center = googleMap.getCenter()
     const newView = {
       center: { lat: center.lat(), lng: center.lng() },
@@ -159,9 +159,7 @@ const makeHandleViewChange = (dispatch, googleMap, history) => {
       height: googleMap.getDiv().offsetHeight,
     }
     throttledDispatches(newView)
-    if (googleMapReactCallbackArg) {
-      history.syncViewToBrowserUrl(newView)
-    }
+    history.syncViewToBrowserUrl(newView)
   }
 }
 
@@ -269,7 +267,7 @@ const MapPage = ({ isDesktop }) => {
       /*
        * Call the handler for the first time since map (re)opened
        */
-      handleViewChangeRef.current(false)
+      handleViewChangeRef.current()
     }
   }, [!typesAccess.isEmpty, googleMap, !!dispatch, hasTypesParams]) //eslint-disable-line
 

--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useDispatch, useSelector } from 'react-redux'
 import { useLocation } from 'react-router-dom'
-import { toast } from 'react-toastify'
 import styled from 'styled-components/macro'
 
 import { VISIBLE_CLUSTER_ZOOM_LIMIT } from '../../constants/map'
@@ -145,13 +144,9 @@ const clusterBounds = ({ lat, lng, zoom }) => {
 }
 const makeHandleViewChange = (dispatch, googleMap, history) => {
   const throttledDispatches = throttle((newView) => {
-    try {
-      dispatch(updateLastMapView(newView))
-      dispatch(fetchLocations())
-      dispatch(fetchFilterCounts())
-    } catch (error) {
-      toast.error(error?.message ?? error)
-    }
+    dispatch(updateLastMapView(newView))
+    dispatch(fetchLocations())
+    dispatch(fetchFilterCounts())
   }, 1000)
 
   return () => {

--- a/src/redux/viewportSlice.js
+++ b/src/redux/viewportSlice.js
@@ -15,12 +15,13 @@ const viewportSlice = createSlice({
        * (if the API was previously loaded but map went off screen)
        */
       // Hold on to the viewport dimensions so we can use it
-      state.lastMapView = {
+      const view = {
         ...action.payload,
         height: action.payload.height || state.lastMapView?.height,
         width: action.payload.width || state.lastMapView?.width,
       }
-      persistentStore.setLastMapViewThrottledSync(state.lastMapView)
+      state.lastMapView = view
+      persistentStore.setLastMapViewThrottledSync(view)
     },
   },
   extraReducers: {

--- a/src/redux/viewportSlice.js
+++ b/src/redux/viewportSlice.js
@@ -1,4 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { toast } from 'react-toastify'
 
 import persistentStore from '../utils/persistentStore'
 import { selectPlace } from './placeSlice'
@@ -21,17 +22,26 @@ const viewportSlice = createSlice({
         width: action.payload.width || state.lastMapView?.width,
       }
       state.lastMapView = view
-      persistentStore.setLastMapViewThrottledSync(view)
+      try {
+        persistentStore.setLastMapViewThrottledSync(view)
+      } catch (error) {
+        toast.error(error?.message ?? error)
+      }
     },
   },
   extraReducers: {
     [selectPlace]: (state, action) => {
-      state.lastMapView = {
+      const view = {
         height: state.lastMapView.height,
         width: state.lastMapView.width,
         ...action.payload.place.view,
       }
-      persistentStore.setLastMapViewImmediateSync(state.lastMapView)
+      state.lastMapView = view
+      try {
+        persistentStore.setLastMapViewImmediateSync(view)
+      } catch (error) {
+        toast.error(error?.message ?? error)
+      }
     },
   },
 })


### PR DESCRIPTION
Closes #1109 
In the map callback, we have these actions:
```
  const throttledDispatches = throttle((newView) => {
    dispatch(updateLastMapView(newView))
    dispatch(fetchLocations())
    dispatch(fetchFilterCounts())
  }, 1000)
```
 `updateLastMapView(newView)` is sync, and the other ones are made from createAsyncThunk, with .rejected handlers toasting the errors. The whole thing is also a callback / setTimeout in the throttle so the error boundary doesn't cover it. So, if  `updateLastMapView(newView)` fails, then the other dispatchers don't happen, and it calls  `src/utils/persistentStore.js` , which code that can throw even though it shouldn't throw for us.

I'm blaming 'somewhere there' for the problem, two possible ones are JSON.stringinfy or setItem. I can sort of reproduce the bug, putting throwing code like `JSON.stringify({ n: 1n }) `  inside setLastMapViewThrottledSync results in a silent failure and call to fetch locations not happening:

The change puts a try/catch about syncing to persistent store, so if it goes wrong, it will say so, and proceed, so the severity is reduced just to an unimportant feature not working and a repeated warning.