### PR TITLE
Don't rely on currentZoom in zoom callbacks, so we can zoom in and out quickly

### DIFF
--- a/src/components/map/MapPage.js
+++ b/src/components/map/MapPage.js
@@ -377,10 +377,14 @@ const MapPage = ({ isDesktop }) => {
   }, [googleMap, getGoogleMaps, isViewingLocation, history])
 
   const zoomIn = () => {
-    googleMap?.setZoom(currentZoom + 1)
+    if (googleMap) {
+      googleMap.setZoom(googleMap.getZoom() + 1)
+    }
   }
   const zoomOut = () => {
-    googleMap?.setZoom(currentZoom - 1)
+    if (googleMap) {
+      googleMap.setZoom(googleMap.getZoom() - 1)
+    }
   }
 
   const toggleShare = useCallback(() => {


### PR DESCRIPTION
Closes #1111