### PR TITLE
fix: Remove the 'Reviews' header when there are no reviews (#1121)

### DIFF
--- a/src/components/location/ReviewsTab.js
+++ b/src/components/location/ReviewsTab.js
@@ -1,0 +1,27 @@
+import { useTranslation } from 'react-i18next'
+
+import { useAppSelector } from '../../redux/hooks'
+import InaturalistReviews from './InaturalistReviews'
+import ReviewForm from './ReviewForm'
+import ReviewList from './ReviewList'
+
+const ReviewsTab = () => {
+  const { t } = useTranslation()
+  const { reviews } = useAppSelector((state) => state.location)
+  const hasReviews = reviews && reviews.length > 0
+
+  return (
+    <div>
+      {hasReviews && (
+        <>
+          <h2>{t('glossary.reviews')}</h2>
+          <ReviewList reviews={reviews} />
+        </>
+      )}
+      <InaturalistReviews />
+      <ReviewForm />
+    </div>
+  )
+}
+
+export default ReviewsTab

--- a/src/components/location/ReviewsTab.test.js
+++ b/src/components/location/ReviewsTab.test.js
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import { configureStore } from '@reduxjs/toolkit'
+
+import ReviewsTab from './ReviewsTab'
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key) => key }),
+}))
+
+jest.mock('./InaturalistReviews', () => () => <div data-testid="inaturalist-reviews" />)
+jest.mock('./ReviewForm', () => () => <div data-testid="review-form" />)
+jest.mock('./ReviewList', () => ({ reviews }) => (
+  <div data-testid="review-list">{reviews.length} reviews</div>
+))
+
+const makeStore = (reviews) =>
+  configureStore({
+    reducer: {
+      location: () => ({ reviews }),
+    },
+  })
+
+describe('ReviewsTab', () => {
+  it('hides the Reviews header and list when there are no reviews', () => {
+    const store = makeStore([])
+    render(
+      <Provider store={store}>
+        <ReviewsTab />
+      </Provider>,
+    )
+    expect(screen.queryByText('glossary.reviews')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('review-list')).not.toBeInTheDocument()
+  })
+
+  it('shows the Reviews header and list when there are reviews', () => {
+    const store = makeStore([{ id: 1, comment: 'Great!' }])
+    render(
+      <Provider store={store}>
+        <ReviewsTab />
+      </Provider>,
+    )
+    expect(screen.getByText('glossary.reviews')).toBeInTheDocument()
+    expect(screen.getByTestId('review-list')).toBeInTheDocument()
+  })
+
+  it('always renders InaturalistReviews and ReviewForm', () => {
+    const store = makeStore([])
+    render(
+      <Provider store={store}>
+        <ReviewsTab />
+      </Provider>,
+    )
+    expect(screen.getByTestId('inaturalist-reviews')).toBeInTheDocument()
+    expect(screen.getByTestId('review-form')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #1121

When a location has no reviews, the `Reviews` header was still being rendered, resulting in an empty section that provided no value to the user. This PR conditionally hides the header when there are no reviews to display, improving the overall cleanliness and clarity of the location detail view.

---

## Changes Made

- **`src/components/location/ReviewsTab.js`**: Updated the component to conditionally render the `Reviews` header only when one or more reviews are present. No changes were made to the underlying review fetching logic or layout structure.
- **`src/components/location/ReviewsTab.test.js`**: Added test cases to verify that the `Reviews` header is hidden when the reviews list is empty and that it remains visible when reviews exist, ensuring the conditional rendering behaves as expected.

---

## Testing

- Verified that the `Reviews` header does **not** appear when a location has zero reviews.
- Verified that the `Reviews` header **does** appear correctly when a location has one or more reviews.
- All existing and newly added unit tests pass successfully.
- Manually tested against locations with and without reviews in the local development environment to confirm expected UI behavior.

---

## Checklist

- [x] Closes #1121
- [x] Code follows the existing style and conventions of the codebase
- [x] New test cases have been added to cover the changed behavior
- [x] All tests pass locally
- [x] No unintended side effects or regressions introduced
- [x] PR is scoped to a single, focused change