### PR TITLE
Remove 'Status' section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@ React-based, mobile-friendly website for Falling Fruit.
 
 **For developers!** More comprehensive documentation is available in [`/docs`](./docs).
 
-## Status
-
-Under development as the future replacement of the existing website ([falling-fruit](https://github.com/falling-fruit/falling-fruit)) and mobile app ([falling-fruit-mobile](https://github.com/falling-fruit/falling-fruit-mobile)). It is live at https://beta.fallingfruit.org. The highest-priority issues are those assigned to the [Beta release](https://github.com/falling-fruit/falling-fruit-web/milestone/5) milestone.
-
 ## Technologies
 
 Built with React, Redux, Reach UI, Styled Components, and Formik. Vercel was once used for automatic deployments.


### PR DESCRIPTION
Removed the 'Status' section from the README.

- beta.fallingfruitfruit.org redirects to fallingfruit and beta release milestone https://github.com/falling-fruit/falling-fruit-web/milestone/5 has been completed. Assuming the beta launch has been completed this section can be removed. If incorrect feel free to close