### PR TITLE
Redirect legacy /profiles/:id links to /users/:id

### DIFF
--- a/src/components/init/redirectRoutes.js
+++ b/src/components/init/redirectRoutes.js
@@ -1,5 +1,5 @@
 import { useSelector } from 'react-redux'
-import { Redirect, Route } from 'react-router-dom'
+import { Redirect, Route, useParams } from 'react-router-dom'
 
 import { addParam, pathWithCurrentView, pathWithView } from '../../utils/appUrl'
 import { useIsDesktop } from '../../utils/useBreakpoint'
@@ -30,6 +30,11 @@ const CommunityFruitTreesRedirect = () => {
   let mapPath = pathWithView('/map', view)
   mapPath = addParam(mapPath, 'f', '4628')
   return <Redirect to={mapPath} />
+}
+
+const ProfileRedirect = () => {
+  const { userId } = useParams()
+  return <Redirect to={pathWithCurrentView(`/users/${userId}`)} />
 }
 
 const SeedLibraryRedirect = () => {
@@ -82,6 +87,10 @@ const redirects = [
   {
     path: ['/seedlibrary', '/seedlibraries'],
     component: SeedLibraryRedirect,
+  },
+  {
+    path: '/profiles/:userId',
+    component: ProfileRedirect,
   },
   {
     path: '/users/sign_in',

--- a/src/components/init/redirectRoutes.js
+++ b/src/components/init/redirectRoutes.js
@@ -89,7 +89,7 @@ const redirects = [
     component: SeedLibraryRedirect,
   },
   {
-    path: '/profiles/:userId',
+    path: '/profiles/:userId([0-9]+)',
     component: ProfileRedirect,
   },
   {


### PR DESCRIPTION
Adds a redirect for the legacy /profiles/:userId path to the current /users/:userId profile route, following the same pattern as the other legacy redirects already in redirectRoutes.js 
(e.g. /imports -> /about/data).

Old /profiles/:id links still exist in the wild despite the path being renamed, and previously they'd hit a dead end instead of reaching the user's profile.

Closes #1138