### PR TITLE
Fix add similar issue for iOS

### DIFF
--- a/src/components/connect/ConnectLocation.js
+++ b/src/components/connect/ConnectLocation.js
@@ -27,7 +27,7 @@ const LessPaddingButton = styled(Button)`
   padding: 0 10px;
 `
 
-const ToastContent = () => {
+const ToastContent = ({ location }) => {
   const { t } = useTranslation()
   const history = useAppHistory()
   const dispatch = useDispatch()
@@ -57,7 +57,7 @@ const ToastContent = () => {
         <LessPaddingButton
           type="button"
           onClick={() => {
-            dispatch(duplicateIntoNewLocation())
+            dispatch(duplicateIntoNewLocation(location))
             history.push(`/locations/init`)
           }}
         >
@@ -225,7 +225,7 @@ const ConnectLocation = ({
       }
     } else if (isSuccessfullyAdded) {
       toastIdRef.current = toast.success(
-        <ToastContent locationId={locationId} />,
+        <ToastContent locationId={locationId} location={location} />,
         {
           autoClose: false,
           style: { width: '100%' },

--- a/src/components/connect/ConnectNewLocation.js
+++ b/src/components/connect/ConnectNewLocation.js
@@ -36,7 +36,13 @@ const ConnectNewLocation = () => {
       // Should only happen for an artificially constructed URL
       history.push('/map')
     }
-  }, [dispatch, locationId, hasInitialView, isDesktop]) //eslint-disable-line
+    /*
+     * Mount-only: after a successful submit, locationId changes from 'new' to
+     * the new location's id while this component is still mounted. Re-running
+     * would call initNewLocation and wipe the just-added location from Redux,
+     * which the success page and 'Add similar' still need.
+     */
+  }, []) //eslint-disable-line
   return null
 }
 

--- a/src/redux/locationSlice.js
+++ b/src/redux/locationSlice.js
@@ -92,7 +92,15 @@ const locationSlice = createSlice({
     clearLocation: (state) => {
       Object.assign(state, initialState)
     },
-    duplicateIntoNewLocation: (state) => {
+    duplicateIntoNewLocation: (state, action) => {
+      /*
+       * The location captured when the success toast was created. Restore it
+       * in case something (e.g. the mobile drawer closing through /map)
+       * cleared the slice before the user tapped 'Add similar'.
+       */
+      if (action.payload) {
+        state.location = action.payload
+      }
       state.isLoading = false
       state.isBeingEdited = false
       state.locationId = 'new'


### PR DESCRIPTION
Was able to reproduce the bug on my iPhone and simulator.

When user submits the location state was getting wiped because the effect was being rerun, which forces a refetch. If the data hasn't already been populated the blank state becomes the new state. So it's a race condition that could potentially effect more than iOS.

Fix tested / works in simulator.

Closes #1143 