### PR TITLE
Upgrade react-split-pane from v2 to v3

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -35,7 +35,13 @@ module.exports = {
             warning.details.includes('source-map-loader')
           )
         },
-      ]
+	]
+
+      webpackConfig.resolve.alias = {
+        ...webpackConfig.resolve.alias,
+        'react/jsx-runtime': require.resolve('react/jsx-runtime.js'),
+        'react/jsx-dev-runtime': require.resolve('react/jsx-dev-runtime.js'),
+      }
 
       return webpackConfig
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^5.0.1",
     "react-select": "^4.3.0",
-    "react-split-pane": "^0.1.92",
+    "react-split-pane": "^3.2.0",
     "react-toastify": "^8.1.0",
     "reaptcha": "^1.7.3",
     "styled-components": "^5.2.1",

--- a/src/components/desktop/DesktopLayout.js
+++ b/src/components/desktop/DesktopLayout.js
@@ -1,6 +1,6 @@
 import { WindowSize } from '@reach/window-size'
 import { Route, Switch } from 'react-router-dom'
-import SplitPane from 'react-split-pane'
+import { Pane, SplitPane } from 'react-split-pane'
 import styled from 'styled-components/macro'
 
 import aboutRoutes from '../about/aboutRoutes'
@@ -57,14 +57,17 @@ const DesktopLayout = () => (
       <Route>
         <WindowSize>
           {({ width: vw }) => (
-            <StyledSplit
-              split="vertical"
-              minSize={MIN_PANE_WIDTH(vw)}
-              maxSize={MAX_PANE_WIDTH(vw)}
-              defaultSize={DEFAULT_PANE_WIDTH(vw)}
-            >
-              <SidePane />
-              <MapPage isDesktop />
+            <StyledSplit direction="horizontal">
+              <Pane
+                minSize={MIN_PANE_WIDTH(vw)}
+                maxSize={MAX_PANE_WIDTH(vw)}
+                defaultSize={DEFAULT_PANE_WIDTH(vw)}
+              >
+                <SidePane />
+              </Pane>
+              <Pane>
+                <MapPage isDesktop />
+              </Pane>
             </StyledSplit>
           )}
         </WindowSize>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10188,7 +10188,7 @@ prompts@^2.0.1, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -10473,11 +10473,6 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-react-lifecycles-compat@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
-  integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
-
 react-loading-skeleton@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-2.2.0.tgz#b8ce516f9a2471e90d7d9ead35d61425367e3340"
@@ -10631,21 +10626,10 @@ react-side-effect@^2.1.0:
   resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.2.tgz#dc6345b9e8f9906dc2eeb68700b615e0b4fe752a"
   integrity sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==
 
-react-split-pane@^0.1.92:
-  version "0.1.92"
-  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-0.1.92.tgz#68242f72138aed95dd5910eeb9d99822c4fc3a41"
-  integrity sha512-GfXP1xSzLMcLJI5BM36Vh7GgZBpy+U/X0no+VM3fxayv+p1Jly5HpMofZJraeaMl73b3hvlr+N9zJKvLB/uz9w==
-  dependencies:
-    prop-types "^15.7.2"
-    react-lifecycles-compat "^3.0.4"
-    react-style-proptype "^3.2.2"
-
-react-style-proptype@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-style-proptype/-/react-style-proptype-3.2.2.tgz#d8e998e62ce79ec35b087252b90f19f1c33968a0"
-  integrity sha512-ywYLSjNkxKHiZOqNlso9PZByNEY+FTyh3C+7uuziK0xFXu9xzdyfHwg4S9iyiRRoPCR4k2LqaBBsWVmSBwCWYQ==
-  dependencies:
-    prop-types "^15.5.4"
+react-split-pane@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-split-pane/-/react-split-pane-3.2.0.tgz#4b3da8b77addfb98293c8354fdd028411f0ecefc"
+  integrity sha512-tH2SaMqBZ7Ypcmj6I/2fIR0gdeE0Q5ve66T51UyXcSqIgPGJh40bOMTVCAFjB0Q3OB5+Aw/4ECVWU+YU9SL88Q==
 
 react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
   version "2.2.3"


### PR DESCRIPTION
Closes #1207

## Summary
Upgrade `react-split-pane` from v2 to v3 to fix compatibility with React 17.

## Changes
- Bump `react-split-pane` to v3 in `package.json`
- Migrate `DesktopLayout.js` to the new v3 API:
  - Named imports: `{ SplitPane, Pane }`
  - `split="vertical"` → `direction="horizontal"`
  - Wrap children in `<Pane>`
  - Move `minSize` / `maxSize` / `defaultSize` to `<Pane>`
- Add Webpack alias for `react/jsx-runtime` in `craco.config.js` to fix ESM resolution under React 17

## Notes
- Unrelated warnings (Redux Toolkit deprecation, Google Maps billing) are out of scope.
- The `aria-description` warning originates from `react-split-pane` v3 itself and is non-fatal.